### PR TITLE
Fix StrictMode chunk doubling in chat streaming

### DIFF
--- a/dashboard/app/chat/page.tsx
+++ b/dashboard/app/chat/page.tsx
@@ -73,14 +73,13 @@ export default function ChatPage() {
           eventSource.close();
           setStreaming(false);
         } else if (payload.chunk) {
-          setMessages((prev) => {
-            const updated = [...prev];
-            const lastMsg = updated[updated.length - 1];
-            if (lastMsg && lastMsg.role === "assistant") {
-              lastMsg.content += payload.chunk;
-            }
-            return updated;
-          });
+          setMessages((prev) =>
+            prev.map((m, i) =>
+              i === prev.length - 1 && m.role === "assistant"
+                ? { ...m, content: m.content + payload.chunk }
+                : m
+            )
+          );
         }
       };
 


### PR DESCRIPTION
## Summary
- Replace mutating `setMessages` updater in `dashboard/app/chat/page.tsx` with a pure one that builds a new message object per chunk
- Fixes the dev-only "every chunk renders twice" symptom from React 18 StrictMode double-invoking impure updaters

## Test plan
- [x] Run `next dev`, send a multi-paragraph prompt, confirm output renders once
- [x] Production build still streams correctly (single invocation path was already fine)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)