### PR TITLE
Reload-agent endpoint that preserves session

### DIFF
--- a/bin/agent-server.py
+++ b/bin/agent-server.py
@@ -427,6 +427,18 @@ async def restart_agent(agent: str):
     response_buffers[agent] = ""
     await start_agent_subprocess(agent)
 
+
+async def reload_agent(agent: str):
+    """Bounce the subprocess but keep the session — used to pick up new
+    SYSTEM_PROMPT / persona / MCP config without dropping conversation
+    context. The respawn calls --resume on the existing session_id.
+    """
+    log.info(f"Reloading {agent} (preserving session)")
+    await kill_agent_subprocess(agent)
+    agent_last_cost.pop(agent, None)
+    response_buffers[agent] = ""
+    await start_agent_subprocess(agent)
+
 # =============================================================================
 # Cost Tracking
 # =============================================================================
@@ -996,6 +1008,21 @@ async def handle_agent_reset(request):
     await restart_agent(agent)
     return web.json_response({"status": "reset"})
 
+
+async def handle_agent_reload(request):
+    """POST /agents/{name}/reload - Bounce subprocess, preserve session."""
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer ") or auth_header[7:] != AGENT_SERVER_TOKEN:
+        return web.json_response({"error": "Unauthorized"}, status=401)
+
+    agent = request.match_info.get("name")
+    if agent not in agent_config:
+        return web.json_response({"error": "Unknown agent"}, status=404)
+
+    await reload_agent(agent)
+    return web.json_response({"status": "reloaded"})
+
+
 async def handle_cost(request):
     """POST /cost - Record external cost event"""
     # Check bearer token
@@ -1189,6 +1216,7 @@ def main():
     app.router.add_get("/health", handle_health)
     app.router.add_get("/agents", handle_agents)
     app.router.add_post("/agents/{name}/reset", handle_agent_reset)
+    app.router.add_post("/agents/{name}/reload", handle_agent_reload)
     app.router.add_post("/cost", handle_cost)
     app.router.add_get("/cost/{agent}", handle_cost_get)
 

--- a/dashboard/app/api/agents/[name]/reload/route.ts
+++ b/dashboard/app/api/agents/[name]/reload/route.ts
@@ -12,14 +12,19 @@ export async function POST(
   }
 
   try {
-    const response = await agentFetch("/restart-session", {
+    const response = await agentFetch(`/agents/${name}/reload`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ agent: name }),
     });
 
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Failed to reload agent: ${response.statusText}` },
+        { status: response.status }
+      );
+    }
+
     const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
+    return NextResponse.json(data);
   } catch (error) {
     return NextResponse.json(
       { error: "Failed to reload agent" },

--- a/dashboard/app/chat/page.tsx
+++ b/dashboard/app/chat/page.tsx
@@ -19,6 +19,8 @@ export default function ChatPage() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
+  const [reloading, setReloading] = useState(false);
+  const [reloadMsg, setReloadMsg] = useState<string | null>(null);
   const messagesEnd = useRef<HTMLDivElement>(null);
 
   const agents = agentData?.agents ? Object.keys(agentData.agents) : [];
@@ -33,6 +35,28 @@ export default function ChatPage() {
   useEffect(() => {
     messagesEnd.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
+
+  async function handleReload() {
+    if (!agent || reloading || streaming) return;
+    setReloading(true);
+    setReloadMsg(`Reloading ${agent}…`);
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agent)}/reload`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: "Request failed" }));
+        setReloadMsg(`Reload failed: ${err.error || res.statusText}`);
+      } else {
+        setReloadMsg(`${agent} reloaded — session preserved.`);
+        setTimeout(() => setReloadMsg(null), 4000);
+      }
+    } catch (err) {
+      setReloadMsg(`Reload error: ${err instanceof Error ? err.message : "unknown"}`);
+    } finally {
+      setReloading(false);
+    }
+  }
 
   async function handleSend(e: FormEvent) {
     e.preventDefault();
@@ -111,6 +135,18 @@ export default function ChatPage() {
             <option key={a} value={a}>{a}</option>
           ))}
         </select>
+        <button
+          type="button"
+          onClick={handleReload}
+          disabled={reloading || streaming || !agent}
+          title="Bounce subprocess, preserve session — picks up SYSTEM_PROMPT / persona / MCP changes"
+          className="px-3 py-2 bg-gray-900 hover:bg-gray-800 disabled:opacity-50 border border-gray-800 rounded text-gray-300 text-sm transition-colors"
+        >
+          {reloading ? "Reloading…" : "↻ Reload"}
+        </button>
+        {reloadMsg && (
+          <span className="text-xs text-gray-400">{reloadMsg}</span>
+        )}
       </div>
 
       <div className="flex-1 overflow-auto py-2 mb-4">


### PR DESCRIPTION
## Summary
- `bin/agent-server.py`: add `reload_agent()` helper and `POST /agents/{name}/reload` — bounces the subprocess but leaves the `sessions` row alone, so the respawn picks up `--resume` and conversation history survives.
- `dashboard/app/api/agents/[name]/reload/route.ts`: was calling a nonexistent `/restart-session` endpoint; repoint at the new agent-server route.
- `dashboard/app/chat/page.tsx`: surface a `↻ Reload` button in the chat header with a transient status hint.

## Test plan
- [x] Edit `agents/<name>/SYSTEM_PROMPT.md`, click Reload, verify subprocess bounces in ~2s and follow-up message reflects new prompt
- [x] Confirm prior turns still in context after reload (asked "what did I just say?", got correct answer)
- [x] Confirm `/agents/{name}/reset` still clears the session as before

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)