### PR TITLE
Persist + reload dashboard chat history

### DIFF
--- a/dashboard/app/api/chat/history/route.ts
+++ b/dashboard/app/api/chat/history/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isAuthenticated, unauthorizedResponse } from "@/lib/api";
+import { join } from "path";
+
+const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT || "/workspace";
+
+export async function GET(request: NextRequest) {
+  if (!isAuthenticated(request.cookies.get("karakos_session")?.value)) {
+    return unauthorizedResponse();
+  }
+
+  const url = request.nextUrl;
+  const agent = url.searchParams.get("agent");
+  const limit = parseInt(url.searchParams.get("limit") || "50", 10);
+
+  if (!agent) {
+    return NextResponse.json({ error: "Missing agent" }, { status: 400 });
+  }
+
+  try {
+    const dbPath = join(WORKSPACE_ROOT, "data/memory/agent-server.db");
+    const sqlite3 = await import("sqlite3").then((m) => m.default);
+    const { open } = await import("sqlite");
+    const db = await open({ filename: dbPath, driver: sqlite3.Database });
+
+    const rows = await db.all<
+      Array<{
+        message_id: string;
+        content: string;
+        response: string | null;
+        created_at: string;
+        processed: number;
+      }>
+    >(
+      `SELECT message_id, content, response, created_at, processed
+       FROM message_queue
+       WHERE agent = ? AND channel = 'dashboard'
+       ORDER BY created_at DESC
+       LIMIT ?`,
+      agent,
+      limit
+    );
+    await db.close();
+
+    // Reverse so callers get chronological order
+    const ordered = rows.reverse();
+    const messages: {
+      role: "user" | "assistant";
+      content: string;
+      ts: string;
+      messageId: string;
+      processed?: number;
+    }[] = [];
+    for (const row of ordered) {
+      if (row.content) {
+        messages.push({
+          role: "user",
+          content: row.content,
+          ts: row.created_at,
+          messageId: row.message_id,
+        });
+      }
+      // Include in-progress assistant turns (processed=1) as well as completed
+      // ones (processed=2) so a mid-stream reload can render the partial reply.
+      if (row.processed >= 1) {
+        messages.push({
+          role: "assistant",
+          content: row.response ?? "",
+          ts: row.created_at,
+          messageId: row.message_id,
+          processed: row.processed,
+        });
+      }
+    }
+
+    return NextResponse.json({ messages });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Failed to load history: ${error instanceof Error ? error.message : "unknown"}` },
+      { status: 500 }
+    );
+  }
+}

--- a/dashboard/app/chat/page.tsx
+++ b/dashboard/app/chat/page.tsx
@@ -58,6 +58,37 @@ export default function ChatPage() {
     }
   }
 
+  // Seed messages from server-side history when an agent is selected. The
+  // chat page kept no record across reloads even though message_queue stored
+  // every turn — pulling the last N entries restores continuity.
+  useEffect(() => {
+    if (!agent) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/chat/history?agent=${encodeURIComponent(agent)}&limit=50`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        const seeded: ChatMessage[] = (data.messages || []).map(
+          (m: { role: "user" | "assistant"; content: string; ts: string }) => ({
+            role: m.role,
+            content: m.content,
+            ts: m.ts,
+          })
+        );
+        setMessages(seeded);
+      } catch {
+        // ignore — empty chat is acceptable failure mode
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent]);
+
   async function handleSend(e: FormEvent) {
     e.preventDefault();
     if (!input.trim() || !agent || streaming) return;


### PR DESCRIPTION
## Summary
- New `GET /api/chat/history?agent=<name>&limit=N` reads `message_queue` directly and returns ordered user/assistant pairs. Includes in-progress rows (`processed >= 1`) so a mid-stream reload can render the partial reply.
- `dashboard/app/chat/page.tsx` fetches the endpoint when an agent is selected and seeds `messages` from the result.

The existing `/api/messages` only reads daily JSONL files from `data/messages/`, which `bin/capture.py` writes — and capture is wired only into the Discord relay, not dashboard chat. So even if the chat page tried, that path would have come up empty.

## Test plan
- [x] Send a few turns to a dashboard agent, hard-reload `/chat`, confirm prior turns reappear in order
- [x] Switch agents in the dropdown, confirm history matches the selected agent
- [x] New agent with no `dashboard`-channel rows yields an empty chat (not an error)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)