### PR TITLE
First-boot onboarding flow for fresh agents

### DIFF
--- a/agents/templates/onboarding.md
+++ b/agents/templates/onboarding.md
@@ -1,0 +1,62 @@
+# First-Boot Onboarding
+
+This is your first conversation. The persona directory at
+`agents/{{AGENT_NAME}}/persona/` is empty — meaning nobody has told you yet
+who they are, what they do, what they care about, or how they want you to
+work.
+
+Your normal behavior described in the system prompt is the *shape* of
+what you do; the *content* — projects, working style, priorities, peeves —
+is unknown. Don't guess. Don't pretend you already know them. Don't run
+any tools yet (no calendar sweep, no email, no Jira).
+
+You'll be talking to {{OWNER_NAME}} — that's the name the system was
+installed under, but it may not be how they actually like to be addressed.
+Confirm before you commit to it.
+
+## What to do on this first turn
+
+1. Greet briefly — one or two sentences. Use {{OWNER_NAME}} for now.
+2. Tell them you're freshly booted and have no persona yet.
+3. Ask a small set of grounded questions. Don't dump a survey on them. Pick
+   the things that most change how you behave day-to-day:
+   - **Preferred name / form of address.** Confirm "{{OWNER_NAME}}" works,
+     or ask what they'd rather you call them (first name, nickname, full
+     name, no name at all — whatever).
+   - What they do (role, company, kind of work).
+   - The 1–3 active projects they most want you tracking.
+   - How they like communication (length, tone, what to avoid).
+   - Any standing rules — things to never do, things to always do.
+4. Wait for answers. Follow up where useful, but keep it tight — the goal
+   is enough to act, not a complete picture.
+
+## After they've answered
+
+Once you have something workable, **write what you learned to the persona
+directory** so future boots inherit it. Use the Write tool to create one
+file per topic, named for what it covers:
+
+- `agents/{{AGENT_NAME}}/persona/identity.md` — who they are, role,
+  company, working context, preferred name
+- `agents/{{AGENT_NAME}}/persona/projects.md` — active projects to track
+- `agents/{{AGENT_NAME}}/persona/communication.md` — voice, tone, length,
+  things to avoid
+- `agents/{{AGENT_NAME}}/persona/rules.md` — standing do's and don'ts
+
+Each file should be plain Markdown, no frontmatter, written first-person
+("They are…", "They prefer…", "They want me to…") — or by their name if
+they gave you one. These get loaded as your persona, so what you write
+here is what you become. Concise, no fluff.
+
+After writing, briefly tell them what you saved and where, and ask if
+anything's wrong. Then continue normally.
+
+## Important
+
+- Existence of any non-empty `.md` file in `agents/{{AGENT_NAME}}/persona/`
+  is what stops this onboarding from running again. Don't write empty
+  files. Don't write placeholders. Write only what they actually told you.
+- If they push back ("not now", "skip this") — drop it. Don't insist. Be
+  useful as a generic assistant for the session and try again another time.
+- The preferred name they give you should be reflected throughout the
+  persona files — don't keep writing "{{OWNER_NAME}}" if they corrected it.

--- a/bin/agent-server.py
+++ b/bin/agent-server.py
@@ -309,6 +309,36 @@ def load_persona_files(agent: str) -> str:
 
     return "\n\n".join(persona_parts)
 
+
+def load_onboarding_prompt(agent: str) -> str:
+    """Return the onboarding prompt iff persona is empty.
+
+    Gated on persona content (not session-resume state) so wiping the DB
+    doesn't retrigger onboarding once the user has given the agent its
+    identity. Substitutes a small set of placeholders so the file can be
+    shared across agent renames.
+    """
+    persona_dir = WORKSPACE_ROOT / "agents" / agent / "persona"
+    if persona_dir.exists() and any(
+        f.read_text().strip() for f in persona_dir.glob("*.md") if f.is_file()
+    ):
+        return ""
+
+    onboarding_path = WORKSPACE_ROOT / "agents" / agent / "onboarding.md"
+    if not onboarding_path.exists():
+        return ""
+
+    text = onboarding_path.read_text()
+    substitutions = {
+        "{{AGENT_NAME}}": agent,
+        "{{OWNER_NAME}}": os.environ.get("OWNER_NAME", "User"),
+        "{{SYSTEM_NAME}}": os.environ.get("SYSTEM_NAME", "karakos"),
+    }
+    for placeholder, value in substitutions.items():
+        text = text.replace(placeholder, value)
+    return text.strip()
+
+
 async def start_agent_subprocess(agent: str):
     """Start persistent Claude subprocess for agent"""
     config = agent_config.get(agent, {})
@@ -333,6 +363,14 @@ async def start_agent_subprocess(agent: str):
 
     # Load persona
     persona_content = load_persona_files(agent)
+
+    # First-boot gate: if no persona has been written yet, prepend the
+    # onboarding prompt so the agent asks the user for guidance instead
+    # of arriving fully-formed.
+    onboarding = load_onboarding_prompt(agent)
+    if onboarding:
+        log.info(f"Injecting onboarding prompt for {agent} (persona is empty)")
+        persona_content = onboarding + ("\n\n" + persona_content if persona_content else "")
 
     # Load last session summary if available
     last_session = await load_last_session(agent)

--- a/bin/create-agent.sh
+++ b/bin/create-agent.sh
@@ -129,6 +129,18 @@ sed \
 # Create empty voice.md for user customization
 touch "$AGENT_DIR/persona/voice.md"
 
+# Drop in a templated onboarding.md so the very first turn asks the user
+# for guidance instead of behaving as a fully-formed assistant. Removed
+# automatically (well — ignored) once the persona dir has any content.
+ONBOARDING_TEMPLATE="$WORKSPACE_ROOT/agents/templates/onboarding.md"
+if [[ -f "$ONBOARDING_TEMPLATE" ]]; then
+    sed \
+        -e "s/{{AGENT_NAME}}/$AGENT_NAME/g" \
+        -e "s/{{SYSTEM_NAME}}/$SYSTEM_NAME/g" \
+        -e "s/{{OWNER_NAME}}/$OWNER_NAME/g" \
+        "$ONBOARDING_TEMPLATE" > "$AGENT_DIR/onboarding.md"
+fi
+
 # Create inbox directory for dispatch adapter
 mkdir -p "$WORKSPACE_ROOT/inbox/$AGENT_NAME"
 


### PR DESCRIPTION
## Summary
- New `agents/templates/onboarding.md` — instructs the agent to greet briefly, ask 4 grounded questions (name, role, projects, comm style + standing rules), and write what it learns into `agents/<name>/persona/*.md`
- `bin/create-agent.sh` drops a per-agent `onboarding.md` from the template (same `{{AGENT_NAME}} / {{OWNER_NAME}} / {{SYSTEM_NAME}}` substitutions as `SYSTEM_PROMPT.md`)
- `bin/agent-server.py`: new `load_onboarding_prompt()` returns the file iff `agents/<name>/persona/` has no non-empty markdown. Gated on persona-emptiness, **not** `is_resume`, so wiping the DB after onboarding doesn't retrigger it. `start_agent_subprocess` prepends it via `--append-system-prompt` on first boot only.

## Test plan
- [x] Fresh agent (`create-agent.sh new-agent`) — first message yields a "Hey, I'm <name>, tell me about yourself…" exchange
- [x] After agent writes `persona/identity.md` etc., subsequent boots skip the onboarding text entirely
- [x] Drop the agent-server DB and re-spawn — onboarding does not re-fire (persona files still on disk)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)