### PR TITLE
feat: dashboard ⌘ Terminal button (closes #43)

### DIFF
--- a/dashboard/app/api/agents/[name]/open-terminal/route.ts
+++ b/dashboard/app/api/agents/[name]/open-terminal/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { resolve } from "path";
+import { isAuthenticated, unauthorizedResponse } from "@/lib/api";
+
+const execFileP = promisify(execFile);
+
+// Validate agent name to prevent injection into the AppleScript string.
+const NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const { name } = await params;
+
+  if (!isAuthenticated(request.cookies.get("karakos_session")?.value)) {
+    return unauthorizedResponse();
+  }
+
+  if (!NAME_RE.test(name)) {
+    return NextResponse.json({ error: "Invalid agent name" }, { status: 400 });
+  }
+
+  if (process.platform !== "darwin") {
+    return NextResponse.json(
+      { error: "Open Terminal is macOS-only", platform: process.platform },
+      { status: 501 }
+    );
+  }
+
+  // Repo root: dashboard/ lives one directory below the package root.
+  const repoRoot = resolve(process.cwd(), "..");
+
+  // Use KARA_CHANNEL=dashboard so the CLI shares the dashboard's chat log
+  // (the history view filters channel='dashboard').
+  const cmd = `cd '${repoRoot}' && KARA_AGENT='${name}' KARA_CHANNEL=dashboard ./bin/kara`;
+
+  // Each AppleScript line is a separate -e arg. Embedding newlines in a
+  // single quoted arg breaks AppleScript parsing.
+  const args = [
+    "-e", `tell application "Terminal"`,
+    "-e", "activate",
+    "-e", `do script "${cmd}"`,
+    "-e", "end tell",
+  ];
+
+  try {
+    await execFileP("osascript", args, { timeout: 5000 });
+    return NextResponse.json({ status: "opened", agent: name });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    return NextResponse.json(
+      { error: `Failed to open Terminal: ${message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/dashboard/app/chat/page.tsx
+++ b/dashboard/app/chat/page.tsx
@@ -25,6 +25,7 @@ export default function ChatPage() {
   const [streaming, setStreaming] = useState(false);
   const [reloading, setReloading] = useState(false);
   const [reloadMsg, setReloadMsg] = useState<string | null>(null);
+  const [openingTerminal, setOpeningTerminal] = useState(false);
   const messagesEnd = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -40,6 +41,28 @@ export default function ChatPage() {
   useEffect(() => {
     messagesEnd.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
+
+  async function handleOpenTerminal() {
+    if (!agent || openingTerminal) return;
+    setOpeningTerminal(true);
+    setReloadMsg(`Opening ${agent} in Terminal…`);
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agent)}/open-terminal`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: "Request failed" }));
+        setReloadMsg(`Terminal failed: ${err.error || res.statusText}`);
+      } else {
+        setReloadMsg(`${agent} opened in Terminal.`);
+        setTimeout(() => setReloadMsg(null), 4000);
+      }
+    } catch (err) {
+      setReloadMsg(`Terminal error: ${err instanceof Error ? err.message : "unknown"}`);
+    } finally {
+      setOpeningTerminal(false);
+    }
+  }
 
   async function handleReload() {
     if (!agent || reloading || streaming) return;
@@ -201,6 +224,15 @@ export default function ChatPage() {
           className="px-3 py-2 bg-gray-900 hover:bg-gray-800 disabled:opacity-50 border border-gray-800 rounded text-gray-300 text-sm transition-colors"
         >
           {reloading ? "Reloading…" : "↻ Reload"}
+        </button>
+        <button
+          type="button"
+          onClick={handleOpenTerminal}
+          disabled={openingTerminal || !agent}
+          title="Open this agent in a Terminal window (macOS only) — REPL with slash commands, mirrors into this chat log"
+          className="px-3 py-2 bg-gray-900 hover:bg-gray-800 disabled:opacity-50 border border-gray-800 rounded text-gray-300 text-sm transition-colors"
+        >
+          {openingTerminal ? "Opening…" : "⌘ Terminal"}
         </button>
         {reloadMsg && (
           <span className="text-xs text-gray-400">{reloadMsg}</span>


### PR DESCRIPTION
## Summary

Adds a `⌘ Terminal` button to the dashboard chat header. Clicking it `osascript`s a Terminal window running `bin/kara` (from #53) bound to the active agent with `KARA_CHANNEL=dashboard`, so messages typed in the new Terminal mirror back into the same chat log.

## Endpoint

`POST /api/agents/[name]/open-terminal`

- macOS only — returns 501 elsewhere.
- Agent name validated against `/^[a-zA-Z0-9_-]+$/` before AppleScript interp.
- Each AppleScript line passed as a separate `-e` arg (embedding newlines in a single quoted arg breaks AppleScript parsing — caveat called out in the issue spec).

## UI

`⌘ Terminal` button next to `↻ Reload`, shares the `reloadMsg` status slot for feedback.

## Test plan

- [x] `pytest tests/test_smoke_docker.py::TestNextjsRouteExports` — route exports validate
- [x] Full suite green
- [ ] Manual on macOS: click the button, confirm Terminal opens with `kara` REPL
- [ ] Manual on Linux: confirm 501 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)