### PR TITLE
feat: karakos-admin MCP server (closes #44)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "karakos-admin": {
+      "command": "python3",
+      "args": ["mcp/admin-server.py"],
+      "env": {}
+    }
+  }
+}

--- a/mcp/admin-server.py
+++ b/mcp/admin-server.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+karakos-admin MCP — JSON-RPC 2.0 over stdin/stdout
+
+Exposes the agent-server's HTTP control surface as MCP tools so an operator
+can manage the agent fleet from inside a chat ("spin up a builder named X",
+"reload Amos", "how's the queue") instead of clicking through the dashboard.
+
+Tools:
+  - list_agents       GET  /agents
+  - get_health        GET  /health
+  - reload_agent      POST /agents/{name}/reload
+  - reset_agent       POST /agents/{name}/reset       (destructive)
+  - create_agent      shells bin/create-agent.sh, optionally overwrites
+                      SYSTEM_PROMPT.md and reloads
+
+No SDK dependency — manual JSON-RPC over stdio (initialize, tools/list,
+tools/call, notifications/initialized) so we don't add another dep to
+requirements.txt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+WORKSPACE_ROOT = Path(os.environ.get("WORKSPACE_ROOT", str(Path(__file__).resolve().parent.parent)))
+SERVER_URL = os.environ.get("AGENT_SERVER_URL", f"http://127.0.0.1:{os.environ.get('AGENT_SERVER_PORT', '18791')}").rstrip("/")
+TOKEN = os.environ.get("AGENT_SERVER_TOKEN", "")
+CREATE_AGENT_SH = WORKSPACE_ROOT / "bin" / "create-agent.sh"
+
+NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+PROTOCOL_VERSION = "2024-11-05"
+
+
+# ---------------------------------------------------------------------------
+# transport
+# ---------------------------------------------------------------------------
+
+def _http(method: str, path: str, body: dict | None = None) -> dict:
+    if not TOKEN:
+        raise RuntimeError("AGENT_SERVER_TOKEN not set")
+    url = f"{SERVER_URL}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urlrequest.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urlrequest.urlopen(req, timeout=15) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urlerror.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode()
+        except Exception:
+            pass
+        raise RuntimeError(f"HTTP {exc.code}: {body or exc.reason}") from exc
+    except urlerror.URLError as exc:
+        raise RuntimeError(f"cannot reach {url}: {exc.reason}") from exc
+
+
+# ---------------------------------------------------------------------------
+# tool implementations
+# ---------------------------------------------------------------------------
+
+def tool_list_agents(_args: dict) -> dict:
+    return _http("GET", "/agents")
+
+
+def tool_get_health(_args: dict) -> dict:
+    return _http("GET", "/health")
+
+
+def tool_reload_agent(args: dict) -> dict:
+    name = args.get("name")
+    if not name or not NAME_RE.match(name):
+        raise ValueError(f"invalid agent name: {name!r}")
+    return _http("POST", f"/agents/{name}/reload")
+
+
+def tool_reset_agent(args: dict) -> dict:
+    """Destructive — wipes the agent's session. The agent loses conversation
+    state. Use sparingly."""
+    name = args.get("name")
+    if not name or not NAME_RE.match(name):
+        raise ValueError(f"invalid agent name: {name!r}")
+    return _http("POST", f"/agents/{name}/reset")
+
+
+def tool_create_agent(args: dict) -> dict:
+    name = args.get("name")
+    if not name or not NAME_RE.match(name):
+        raise ValueError(f"invalid agent name: {name!r}")
+    if not CREATE_AGENT_SH.exists():
+        raise RuntimeError(f"{CREATE_AGENT_SH} not found")
+
+    cmd = [str(CREATE_AGENT_SH)]
+    if (template := args.get("template")):
+        cmd += ["--template", template]
+    if (model := args.get("model")):
+        cmd += ["--model", model]
+    if (mt := args.get("max_turns")):
+        cmd += ["--max-turns", str(mt)]
+    cmd.append(name)
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"create-agent.sh timed out: {exc}") from exc
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"create-agent.sh failed (exit {proc.returncode}): {proc.stderr.strip() or proc.stdout.strip()}")
+
+    result: dict = {"created": name, "stdout": proc.stdout.strip()}
+
+    # Optional SYSTEM_PROMPT.md override + reload so the running subprocess
+    # picks up the final prompt without a second create cycle.
+    sp = args.get("system_prompt")
+    if sp:
+        sp_path = WORKSPACE_ROOT / "agents" / name / "SYSTEM_PROMPT.md"
+        sp_path.parent.mkdir(parents=True, exist_ok=True)
+        sp_path.write_text(sp)
+        result["system_prompt_written"] = str(sp_path)
+        try:
+            result["reload"] = _http("POST", f"/agents/{name}/reload")
+        except RuntimeError as exc:
+            result["reload_warning"] = str(exc)
+
+    return result
+
+
+TOOLS = [
+    {
+        "name": "list_agents",
+        "description": "List all registered agents and their state. No args.",
+        "handler": tool_list_agents,
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_health",
+        "description": "Health snapshot of the agent-server: per-agent state, queue depth, alive/dead, session prefix. No args.",
+        "handler": tool_get_health,
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "reload_agent",
+        "description": "Bounce an agent's subprocess while preserving its session. Use after editing SYSTEM_PROMPT.md, persona files, or MCP config.",
+        "handler": tool_reload_agent,
+        "inputSchema": {
+            "type": "object",
+            "properties": {"name": {"type": "string", "description": "Agent name (lowercase, hyphens allowed)"}},
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "reset_agent",
+        "description": "DESTRUCTIVE. Reset an agent's session — wipes conversation state and starts a fresh subprocess. Cannot be undone. Confirm with the user before calling.",
+        "handler": tool_reset_agent,
+        "inputSchema": {
+            "type": "object",
+            "properties": {"name": {"type": "string", "description": "Agent name to reset"}},
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "create_agent",
+        "description": "Scaffold and register a new agent via bin/create-agent.sh. Optional system_prompt overwrites agents/<name>/SYSTEM_PROMPT.md and reloads so the first turn uses the final prompt.",
+        "handler": tool_create_agent,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "New agent name (lowercase, hyphens allowed, must start with a letter)"},
+                "template": {"type": "string", "description": "Base template (default 'primary'). Examples: primary, relay, builder, reviewer"},
+                "model": {"type": "string", "description": "Claude model: opus, sonnet, haiku (default sonnet)"},
+                "max_turns": {"type": "integer", "description": "Max agentic turns per message (default 200)"},
+                "system_prompt": {"type": "string", "description": "Override agents/<name>/SYSTEM_PROMPT.md after scaffolding, then reload"},
+            },
+            "required": ["name"],
+        },
+    },
+]
+
+TOOL_BY_NAME = {t["name"]: t for t in TOOLS}
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC loop
+# ---------------------------------------------------------------------------
+
+def _err(req_id, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "error": {"code": code, "message": message}, "id": req_id}
+
+
+def _ok(req_id, result) -> dict:
+    return {"jsonrpc": "2.0", "result": result, "id": req_id}
+
+
+def handle_request(req: dict) -> dict | None:
+    method = req.get("method", "")
+    req_id = req.get("id")
+    params = req.get("params", {}) or {}
+
+    if method == "initialize":
+        return _ok(req_id, {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "karakos-admin", "version": "1.0.0"},
+        })
+
+    if method == "notifications/initialized":
+        return None  # no response for notifications
+
+    if method == "tools/list":
+        listed = [{"name": t["name"], "description": t["description"], "inputSchema": t["inputSchema"]} for t in TOOLS]
+        return _ok(req_id, {"tools": listed})
+
+    if method == "tools/call":
+        name = params.get("name", "")
+        args = params.get("arguments", {}) or {}
+        tool = TOOL_BY_NAME.get(name)
+        if not tool:
+            return _err(req_id, -32601, f"Unknown tool: {name}")
+        try:
+            result = tool["handler"](args)
+            return _ok(req_id, {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]})
+        except (RuntimeError, ValueError) as exc:
+            return _err(req_id, -32603, str(exc))
+        except Exception as exc:  # noqa: BLE001
+            return _err(req_id, -32603, f"unexpected error: {exc}")
+
+    return _err(req_id, -32601, f"Unknown method: {method}")
+
+
+def main() -> int:
+    # Test mode: --test-tool <name> [args_json]
+    if len(sys.argv) > 1 and sys.argv[1] == "--test-tool":
+        if len(sys.argv) < 3:
+            print("Usage: admin-server.py --test-tool <name> [args_json]", file=sys.stderr)
+            return 2
+        name = sys.argv[2]
+        args = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
+        tool = TOOL_BY_NAME.get(name)
+        if not tool:
+            print(f"unknown tool: {name}", file=sys.stderr)
+            return 2
+        try:
+            print(json.dumps(tool["handler"](args), indent=2))
+            return 0
+        except (RuntimeError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+    # JSON-RPC stdio loop
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            sys.stdout.write(json.dumps(_err(None, -32700, "Parse error")) + "\n")
+            sys.stdout.flush()
+            continue
+        resp = handle_request(req)
+        if resp is not None:
+            sys.stdout.write(json.dumps(resp) + "\n")
+            sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_admin_mcp.py
+++ b/tests/test_admin_mcp.py
@@ -1,0 +1,114 @@
+"""
+Tests for mcp/admin-server.py — karakos-admin MCP.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from conftest import import_script, PACKAGE_ROOT
+
+ADMIN_SERVER = PACKAGE_ROOT / "mcp" / "admin-server.py"
+
+
+@pytest.fixture
+def admin():
+    return import_script("admin-server", file_path=ADMIN_SERVER)
+
+
+def _rpc(lines):
+    """Send JSON lines to admin-server, return parsed responses."""
+    proc = subprocess.run(
+        [sys.executable, str(ADMIN_SERVER)],
+        input="\n".join(json.dumps(l) for l in lines),
+        capture_output=True, text=True, timeout=10,
+        env={**os.environ, "AGENT_SERVER_TOKEN": ""},
+    )
+    return [json.loads(line) for line in proc.stdout.strip().split("\n") if line]
+
+
+def test_admin_server_exists():
+    assert ADMIN_SERVER.exists()
+    assert os.access(ADMIN_SERVER, os.X_OK)
+
+
+def test_initialize():
+    [resp] = _rpc([
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+    ])
+    assert resp["id"] == 1
+    assert resp["result"]["serverInfo"]["name"] == "karakos-admin"
+    assert "tools" in resp["result"]["capabilities"]
+
+
+def test_initialized_notification_no_response():
+    """notifications/initialized must not produce a response (it's a notification)."""
+    responses = _rpc([
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    ])
+    # Only the tools/list response, not the notification
+    assert len(responses) == 1
+    assert responses[0]["id"] == 2
+
+
+def test_tools_list():
+    [resp] = _rpc([
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    ])
+    tool_names = {t["name"] for t in resp["result"]["tools"]}
+    assert tool_names == {"list_agents", "get_health", "reload_agent", "reset_agent", "create_agent"}
+
+
+def test_unknown_method():
+    [resp] = _rpc([
+        {"jsonrpc": "2.0", "id": 1, "method": "bogus/method"},
+    ])
+    assert resp["error"]["code"] == -32601
+
+
+def test_unknown_tool():
+    [resp] = _rpc([
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+         "params": {"name": "nope", "arguments": {}}},
+    ])
+    assert resp["error"]["code"] == -32601
+
+
+def test_invalid_agent_name(admin):
+    """Name validation must reject names that don't match the lowercase regex."""
+    with pytest.raises(ValueError):
+        admin.tool_reload_agent({"name": "Bad-Name"})
+    with pytest.raises(ValueError):
+        admin.tool_reset_agent({"name": "with spaces"})
+    with pytest.raises(ValueError):
+        admin.tool_create_agent({"name": "TOO_UPPER"})
+
+
+def test_missing_token_propagates(admin, monkeypatch):
+    monkeypatch.setattr(admin, "TOKEN", "")
+    with pytest.raises(RuntimeError, match="AGENT_SERVER_TOKEN"):
+        admin.tool_list_agents({})
+
+
+def test_parse_error():
+    """Malformed JSON should produce a parse error response."""
+    proc = subprocess.run(
+        [sys.executable, str(ADMIN_SERVER)],
+        input="not json\n",
+        capture_output=True, text=True, timeout=5,
+    )
+    resp = json.loads(proc.stdout.strip())
+    assert resp["error"]["code"] == -32700
+
+
+def test_mcp_config_at_repo_root():
+    """Spec requires .mcp.json at repo root so spawned claude subprocesses pick it up."""
+    cfg = PACKAGE_ROOT / ".mcp.json"
+    assert cfg.exists(), ".mcp.json must exist at repo root"
+    data = json.loads(cfg.read_text())
+    assert "karakos-admin" in data["mcpServers"]


### PR DESCRIPTION
## Summary

Stdio JSON-RPC MCP at `mcp/admin-server.py` registered via `.mcp.json` at repo root. Exposes the agent-server's HTTP control surface as MCP tools so an operator can manage the agent fleet from inside a chat instead of clicking through the dashboard.

Since the agent-server spawns `claude` without specifying `cwd`, all agents auto-pick up the MCP on next subprocess spawn — no per-agent config edit needed.

## Tools

| Tool | Backing call |
|---|---|
| `list_agents` | `GET /agents` |
| `get_health` | `GET /health` |
| `reload_agent(name)` | `POST /agents/{name}/reload` |
| `reset_agent(name)` | `POST /agents/{name}/reset` (description marks it destructive) |
| `create_agent(name, template?, model?, max_turns?, system_prompt?)` | shells `bin/create-agent.sh`; if `system_prompt` is given, writes `agents/<name>/SYSTEM_PROMPT.md` after scaffolding and reloads so the first turn uses the final prompt |

## Implementation

- Manual JSON-RPC over stdio — no `mcp` / `fastmcp` SDK dep, ~270 lines.
- Handles `initialize`, `notifications/initialized` (no response, per spec), `tools/list`, `tools/call`.
- Agent names regex-validated (`^[a-z][a-z0-9-]*$`) before any HTTP call or shell-out.
- `--test-tool <name> [args_json]` mode for one-off checks outside the JSON-RPC loop.

## Test plan

- [x] `pytest tests/test_admin_mcp.py` — 10 tests pass: exec bit, init handshake, notification produces no response, tools/list, unknown method, unknown tool, name validation, missing token, parse error, `.mcp.json` present at repo root
- [x] Full suite: 78 passed
- [x] Manual smoke: piped initialize + tools/list, got correct responses
- [ ] Manual: hit a real agent-server through `--test-tool list_agents`

## Open questions (carried from spec)

- `reset_agent` doesn't currently refuse if `name` matches the caller. The spec flagged this; not addressed here. Happy to add self-protection in a follow-up.
- `delete_agent` deliberately not exposed — felt wrong as an LLM-callable default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)