### PR TITLE
fix(kara): drop dead-branch tautology in run_oneshot (#63)

### DIFF
--- a/bin/kara
+++ b/bin/kara
@@ -288,8 +288,7 @@ def run_oneshot(content: str, agent: str, channel: str, timeout: int) -> int:
         sys.stdout.flush()
 
     status = _tail(message_id, timeout, on_chunk)
-    if not sys.stdout.isatty() or True:
-        sys.stdout.write("\n")
+    sys.stdout.write("\n")
     if status == "complete":
         return 0
     sys.stderr.write(f"[kara: {status}]\n")


### PR DESCRIPTION
## Summary

- `bin/kara` line 291: `if not sys.stdout.isatty() or True:` was always
  true — a leftover debug toggle Nakir flagged as WARN in the 2026-04-29
  hygiene review.
- The trailing newline is meant to always be written so the streamed
  one-shot response doesn't jam against the next shell prompt.
- Drops the conditional and the dead branch with it.

Closes #63.

## Test plan

- [x] `python3 -m pytest tests/test_kara.py` — 8/8 pass
- [x] `python3 -c "import ast; ast.parse(open('bin/kara').read())"` — syntax clean
- [ ] Manual: `kara "hello"` one-shot — confirm shell prompt lands on a fresh line

🤖 Generated with [Claude Code](https://claude.com/claude-code)