### PR TITLE
fix(create-agent): neutralize python heredoc injection vector (#61)

### DIFF
--- a/bin/create-agent.sh
+++ b/bin/create-agent.sh
@@ -70,12 +70,12 @@ fi
 # Check for name conflict
 AGENTS_JSON="$WORKSPACE_ROOT/config/agents.json"
 if [[ -f "$AGENTS_JSON" ]]; then
-    EXISTING=$(python3 -c "
-import json
-cfg = json.load(open('$AGENTS_JSON'))
-agents = list(cfg.get('agents', {}).keys())
-print(' '.join(agents))
-" 2>/dev/null || echo "")
+    EXISTING=$(AGENTS_JSON="$AGENTS_JSON" python3 - <<'PY' 2>/dev/null || echo ""
+import json, os
+cfg = json.load(open(os.environ['AGENTS_JSON']))
+print(' '.join(cfg.get('agents', {}).keys()))
+PY
+)
     if echo "$EXISTING" | grep -qw "$AGENT_NAME"; then
         echo "Error: agent '$AGENT_NAME' already exists" >&2
         exit 1
@@ -94,27 +94,31 @@ OWNER_NAME="${OWNER_NAME:-User}"
 
 # Build channel list
 CHANNELS=""
-if [[ -f "$WORKSPACE_ROOT/config/channels.json" ]]; then
-    CHANNELS=$(python3 -c "
-import json
-cfg = json.load(open('$WORKSPACE_ROOT/config/channels.json'))
+CHANNELS_JSON="$WORKSPACE_ROOT/config/channels.json"
+if [[ -f "$CHANNELS_JSON" ]]; then
+    CHANNELS=$(CHANNELS_JSON="$CHANNELS_JSON" python3 - <<'PY' 2>/dev/null || echo "- #general"
+import json, os
+cfg = json.load(open(os.environ['CHANNELS_JSON']))
 for name, info in cfg.get('channels', {}).items():
     default = info.get('default_agent', '')
     print(f'- #{name}' + (f' (default: {default})' if default else ''))
-" 2>/dev/null || echo "- #general")
+PY
+)
 fi
 
 # Build other agents list
 OTHER_AGENTS=""
 if [[ -f "$AGENTS_JSON" ]]; then
-    OTHER_AGENTS=$(python3 -c "
-import json
-cfg = json.load(open('$AGENTS_JSON'))
+    OTHER_AGENTS=$(AGENTS_JSON="$AGENTS_JSON" AGENT_NAME="$AGENT_NAME" python3 - <<'PY' 2>/dev/null || echo ""
+import json, os
+cfg = json.load(open(os.environ['AGENTS_JSON']))
+self_name = os.environ['AGENT_NAME']
 for name, info in cfg.get('agents', {}).items():
-    if name != '$AGENT_NAME':
+    if name != self_name:
         model = info.get('model', 'sonnet')
         print(f'- **{name.title()}** ({model})')
-" 2>/dev/null || echo "")
+PY
+)
 fi
 
 # Generate system prompt from template
@@ -149,33 +153,42 @@ echo "  System prompt generated from $TEMPLATE template"
 
 # Register in agents.json (unless ephemeral)
 if [[ "$EPHEMERAL" == "false" && -f "$AGENTS_JSON" ]]; then
-    python3 -c "
+    AGENTS_JSON="$AGENTS_JSON" \
+    AGENT_NAME="$AGENT_NAME" \
+    MODEL="$MODEL" \
+    MAX_TURNS="$MAX_TURNS" \
+    DISCORD_TOKEN="$DISCORD_TOKEN" \
+    python3 - <<'PY'
 import json
+import os
 
-with open('$AGENTS_JSON') as f:
+agents_json = os.environ['AGENTS_JSON']
+agent_name = os.environ['AGENT_NAME']
+model = os.environ['MODEL']
+max_turns = int(os.environ['MAX_TURNS'])
+discord_token = os.environ.get('DISCORD_TOKEN', '')
+
+with open(agents_json) as f:
     cfg = json.load(f)
 
 agents = cfg.setdefault('agents', {})
 entry = {
-    'model': '$MODEL',
-    'max_turns': $MAX_TURNS,
-    'system_prompt': 'agents/$AGENT_NAME/SYSTEM_PROMPT.md',
+    'model': model,
+    'max_turns': max_turns,
+    'system_prompt': f'agents/{agent_name}/SYSTEM_PROMPT.md',
 }
 
-# Add Discord token env var if provided
-token = '$DISCORD_TOKEN'
-if token:
-    import os
-    env_var = 'DISCORD_BOT_TOKEN_' + '$AGENT_NAME'.upper().replace('-', '_')
+if discord_token:
+    env_var = 'DISCORD_BOT_TOKEN_' + agent_name.upper().replace('-', '_')
     entry['discord_bot_token_env'] = env_var
     # Note: user must add the actual token to .env
 
-agents['$AGENT_NAME'] = entry
+agents[agent_name] = entry
 
-with open('$AGENTS_JSON', 'w') as f:
+with open(agents_json, 'w') as f:
     json.dump(cfg, f, indent=2)
     f.write('\n')
-"
+PY
     echo "  Registered in agents.json"
 fi
 

--- a/tests/test_create_agent.py
+++ b/tests/test_create_agent.py
@@ -1,0 +1,118 @@
+"""
+Tests for bin/create-agent.sh — agent creation script.
+
+Focus: the heredoc-injection vector flagged in #61. User input
+(`--discord-token`, etc.) is now passed via env vars and read inside
+single-quoted heredocs, so a token containing a single quote cannot
+end the literal and execute arbitrary Python.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).parent.parent
+CREATE_AGENT = PACKAGE_ROOT / "bin" / "create-agent.sh"
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Build a minimal WORKSPACE_ROOT layout the script can run against."""
+    (tmp_path / "agents" / "templates").mkdir(parents=True)
+    (tmp_path / "config").mkdir()
+    (tmp_path / "inbox").mkdir()
+
+    template = tmp_path / "agents" / "templates" / "primary.md"
+    template.write_text(
+        "# {{AGENT_NAME}}\n\nSystem: {{SYSTEM_NAME}}\nOwner: {{OWNER_NAME}}\n"
+        "Channels:\n{{CHANNELS}}\n\nOther agents:\n{{OTHER_AGENTS}}\n"
+    )
+
+    agents_json = tmp_path / "config" / "agents.json"
+    agents_json.write_text(json.dumps({"agents": {}}, indent=2) + "\n")
+
+    return tmp_path
+
+
+def _run(workspace, *args, env_extra=None):
+    env = {
+        **os.environ,
+        "WORKSPACE_ROOT": str(workspace),
+        # Avoid hitting a real agent-server in tests
+        "AGENT_SERVER_PORT": "1",  # 1 → connection refused → script handles gracefully
+        "AGENT_SERVER_TOKEN": "",
+    }
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [str(CREATE_AGENT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_creates_agent_with_simple_name(workspace):
+    result = _run(workspace, "alpha")
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+
+    agent_dir = workspace / "agents" / "alpha"
+    assert agent_dir.is_dir()
+    assert (agent_dir / "SYSTEM_PROMPT.md").is_file()
+
+    agents = json.loads((workspace / "config" / "agents.json").read_text())
+    assert "alpha" in agents["agents"]
+    assert agents["agents"]["alpha"]["model"] == "sonnet"
+
+
+def test_rejects_uppercase_name(workspace):
+    result = _run(workspace, "BadName")
+    assert result.returncode != 0
+    assert "lowercase alphanumeric" in result.stderr
+
+
+def test_discord_token_with_quotes_does_not_inject(workspace):
+    """A token containing single quotes used to terminate the python literal
+    and execute the rest. Verify the env-pass refactor neutralizes that."""
+    # This token would have escaped the old `'$DISCORD_TOKEN'` literal and
+    # injected `__import__('os').system('touch /tmp/PWNED_xxx')` in the
+    # original code. The new implementation reads it from os.environ.
+    sentinel = workspace / "PWNED_should_not_exist"
+    payload = (
+        "x'); __import__('pathlib').Path('"
+        + str(sentinel)
+        + "').touch(); ('"
+    )
+
+    result = _run(workspace, "beta", "--discord-token", payload)
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert not sentinel.exists(), "injection landed — heredoc terminator failed"
+
+    agents = json.loads((workspace / "config" / "agents.json").read_text())
+    assert agents["agents"]["beta"].get("discord_bot_token_env") == "DISCORD_BOT_TOKEN_BETA"
+
+
+def test_register_writes_correct_env_var_name(workspace):
+    """Hyphens in agent names should map to underscores in the env var name."""
+    result = _run(workspace, "ops-relay", "--discord-token", "anything")
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    agents = json.loads((workspace / "config" / "agents.json").read_text())
+    assert agents["agents"]["ops-relay"]["discord_bot_token_env"] == "DISCORD_BOT_TOKEN_OPS_RELAY"
+
+
+def test_no_single_quote_interpolation_in_python_blocks():
+    """Defensive: catch a regression where someone reintroduces `'$VAR'` inside
+    a `python3 -c` or heredoc body. The fixed version uses `os.environ`."""
+    content = CREATE_AGENT.read_text()
+    # Cheap heuristic: every python invocation in the script should use the
+    # env-passing pattern (`<<'PY'`) and never the inline `python3 -c "..."`
+    # form that interpolates shell vars into Python literals.
+    assert "python3 -c \"" not in content, (
+        "Found `python3 -c \"...\"` — switch to `python3 - <<'PY'` with env-passed values."
+    )


### PR DESCRIPTION
## Summary

`bin/create-agent.sh` had four `python3 -c "..."` blocks that interpolated
shell variables (including the unvalidated `--discord-token` argument)
directly into Python single-quoted literals. A token like:

    x'); __import__('os').system('rm -rf …'); ('

would terminate the literal and execute arbitrary Python.

This PR converts all four blocks to `python3 - <<'PY'` heredocs that read
values from the environment via `os.environ`. The single-quoted heredoc
terminator (`<<'PY'`) prevents shell expansion inside the body, so no value
can affect the Python source.

Closes #61.

## Test plan

- [x] New `tests/test_create_agent.py` (5 cases):
  - basic creation works
  - rejects uppercase/invalid names
  - **injection regression**: a malicious `--discord-token` cannot create
    a sentinel file (positive proof the heredoc terminator holds)
  - hyphen-to-underscore env var name mapping
  - guard against future regression: `python3 -c "..."` is forbidden in
    the script
- [x] Full suite: 90/90 pass (`pytest tests/ --ignore=tests/test_smoke_docker.py`)
- [x] `bash -n bin/create-agent.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)