### PR TITLE
fix: tolerate CRLF line endings in container shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Force LF line endings for shell scripts and Docker files. Without this,
+# Windows clones with `core.autocrlf=true` rewrite shebangs to `#!/bin/bash\r`
+# which fails inside the Linux container with `env: 'bash\r': No such file or
+# directory` (exit 127).
+*.sh         text eol=lf
+bin/kara     text eol=lf
+Dockerfile   text eol=lf
+*.dockerfile text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,5 +62,12 @@ RUN install -d -o karakos -g karakos \
         logs logs/agent-streams logs/session-summaries \
         inbox
 
+# Strip CRLF line endings from shell scripts. Belt-and-suspenders for Windows
+# checkouts where git's autocrlf may have rewritten LF -> CRLF, which breaks
+# shebangs inside the Linux container (env: 'bash\r': No such file, exit 127).
+# .gitattributes also forces LF on these files at the repo level.
+RUN find /workspace/bin -type f \( -name '*.sh' -o -name 'kara' \) \
+        -exec sed -i 's/\r$//' {} +
+
 USER karakos
 ENTRYPOINT ["/usr/bin/tini", "--", "/workspace/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Pins LF line endings on `*.sh`, `bin/kara`, and `Dockerfile` via new `.gitattributes` so Windows clones with `core.autocrlf=true` don't break the entrypoint shebang
- Adds a defensive `sed -i 's/\r$//'` pass in the Dockerfile for `bin/*.sh` + `bin/kara`, so existing checkouts that already have CRLF still build a working image

## Why
Ian hit `env: 'bash\r': No such file or directory` (exit 127) on install. Diagnosis from Docker AI confirmed CRLF in `entrypoint.sh` — the file was LF in the repo, but his Windows checkout converted it. Without `.gitattributes` enforcement, every Windows clone is a landmine.

## Test plan
- [ ] Ian rebuilds with this branch — container starts cleanly
- [ ] `git clone` on a fresh Windows host shows `entrypoint.sh` as LF
- [ ] Linux/macOS builds still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)