### PR TITLE
feat: ship prebuilt multi-arch image to GHCR (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,6 @@ jobs:
 
       - name: Validate docker-compose.yml
         run: docker compose -f config/docker-compose.yml config --quiet
+
+      - name: Validate docker-compose.dev.yml overlay
+        run: docker compose -f config/docker-compose.yml -f config/docker-compose.dev.yml config --quiet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit SHA to build (defaults to current ref)"
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve image version
+        id: version
+        run: |
+          # For workflow_dispatch with an explicit ref input, use it as the
+          # version source so metadata-action computes semver tags correctly.
+          # For tag-triggered runs, github.ref_name already holds the tag (e.g. v1.3).
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.ref }}" ]; then
+            echo "value=${{ inputs.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "value=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/mcarmody/karakos
+          tags: |
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ steps.version.outputs.value }}
+            type=semver,pattern=v{{major}},value=${{ steps.version.outputs.value }}
+            type=raw,value=latest
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  smoke-pull:
+    needs: build-push
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and smoke test (${{ matrix.platform }})
+        run: |
+          # Pull the freshly-published image by digest to ensure we test the
+          # artifact we just pushed, not a cached layer from a previous release.
+          IMAGE="ghcr.io/mcarmody/karakos@${{ needs.build-push.outputs.image_digest }}"
+          docker pull --platform ${{ matrix.platform }} "$IMAGE"
+
+          # Verify dashboard was built into the image
+          docker run --rm --platform ${{ matrix.platform }} --entrypoint test \
+            "$IMAGE" -d /workspace/dashboard/.next
+
+          # Verify Python dependencies are importable
+          docker run --rm --platform ${{ matrix.platform }} --entrypoint python3 \
+            "$IMAGE" -c "import aiohttp, aiosqlite, discord; print('ok')"
+
+          # Verify Node.js is present (used by Claude CLI)
+          docker run --rm --platform ${{ matrix.platform }} --entrypoint node \
+            "$IMAGE" --version

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ curl -fsSL https://raw.githubusercontent.com/mcarmody/karakos-package/main/insta
 irm https://raw.githubusercontent.com/mcarmody/karakos-package/main/install.ps1 | iex
 ```
 
-The installer handles prerequisites (Docker, Git, jq), clones the repo, runs the setup wizard, and starts the system. Open http://localhost:3000 when it's done.
+The installer handles prerequisites (Docker, Git, jq), clones the repo, runs the setup wizard, pulls the prebuilt image from GHCR, and starts the system. Open http://localhost:3000 when it's done.
 
 ## What is Karakos?
 

--- a/config/docker-compose.dev.yml
+++ b/config/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+# Development override — builds the image locally instead of pulling from GHCR.
+#
+# Usage:
+#   docker compose -f config/docker-compose.yml -f config/docker-compose.dev.yml up
+#
+# This is only needed if you are actively modifying the Dockerfile or
+# Python/Node dependencies and want to test changes before publishing a release.
+# Regular users should use docker-compose.yml on its own (docker compose pull).
+
+services:
+  karakos:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: karakos-dev:local

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   karakos:
-    build:
-      context: ..
-      dockerfile: Dockerfile
+    image: ghcr.io/mcarmody/karakos:${KARAKOS_VERSION:-latest}
     env_file: .env
     volumes:
       # Bind-mount config + agents from the host so setup.sh's output (the

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -195,7 +195,32 @@ The system can modify itself through the builder agent:
 | `skills/*/` | Agent session reset | Dashboard → Reset |
 | `config/agents.json` | Agent server restart | POST `/restart/server` |
 | `bin/agent-server.py` | Agent server restart | POST `/restart/server` |
-| `Dockerfile` | Container rebuild | `docker compose up --build` |
+| `Dockerfile` | Container rebuild | see [Local development build](#local-development-build) |
+
+## Local Development Build
+
+Production installs pull a prebuilt image from GHCR (`docker compose pull`).
+If you are modifying the `Dockerfile` or Python/Node dependencies and need to
+test those changes before a release, use the dev compose override:
+
+```bash
+docker compose \
+  -f config/docker-compose.yml \
+  -f config/docker-compose.dev.yml \
+  up --build -d
+```
+
+`config/docker-compose.dev.yml` overlays `build: .` back onto the service so
+your local changes are compiled into an image named `karakos-dev:local`.
+Bring the stack back down and return to the prebuilt image at any time with:
+
+```bash
+docker compose down
+docker compose -f config/docker-compose.yml up -d
+```
+
+The dev override is intentionally not committed to production flows — it is
+only for contributors iterating on the image itself.
 
 ## Environment Variables
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,12 +39,21 @@ The wizard saves progress, so you can quit and resume with `./setup.sh`.
 ## Start
 
 ```bash
+docker compose pull
 docker compose up -d
 ```
 
-First build takes 5-10 minutes (downloads base images, installs dependencies, builds dashboard).
+`docker compose pull` downloads the prebuilt multi-arch image from GHCR (~1.2 GB).
+No local build step — startup is fast once the image is on disk.
 
-**Expected image size:** ~1.2GB (multi-stage build with slim base images)
+**Version pinning:** To stay on a specific release and control when you upgrade, set
+`KARAKOS_VERSION` in `config/.env`:
+
+```bash
+KARAKOS_VERSION=v1.3
+```
+
+Then `docker compose up -d` will use that version instead of `latest`.
 
 ## Verify
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,6 +2,13 @@
 
 Manual upgrade instructions. Karakos does not auto-update.
 
+Karakos ships prebuilt multi-arch images to GHCR. The upgrade path is
+`docker compose pull && docker compose up -d` — no local build required.
+
+`latest` always tracks the newest release. To control when you upgrade, pin
+`KARAKOS_VERSION` in `config/.env` (e.g. `KARAKOS_VERSION=v1.3`). Remove the
+pin or update it when you are ready to move to a newer release.
+
 ## Version Check
 
 The system checks for updates weekly and posts to #signals if a newer version is available. You can also check manually:
@@ -48,13 +55,15 @@ git stash pop
 
 Read the release notes for your version jump. Breaking changes are documented in the GitHub release.
 
-### 5. Rebuild and Start
+### 5. Pull and Start
 
 ```bash
-docker compose up --build -d
+docker compose pull
+docker compose up -d
 ```
 
-The `--build` flag rebuilds the container with any new dependencies or dashboard changes.
+`docker compose pull` downloads the prebuilt image for the new release from GHCR.
+No local build step required.
 
 ### 6. Verify
 
@@ -89,8 +98,9 @@ cp config/.env.backup config/.env
 # Check out previous version
 git checkout v1.0.0  # or whatever version you were on
 
-# Rebuild
-docker compose up --build -d
+# Pull that version's image and start
+docker compose pull
+docker compose up -d
 ```
 
 ## Version History


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml`: builds `linux/amd64` + `linux/arm64` via `docker/build-push-action`, pushes `ghcr.io/mcarmody/karakos` with semver tags (`v1.3`, `v1`, `latest`). Triggers on `v*` tag push and `workflow_dispatch` (optional `ref` input for backfills like v1.3). Post-push `smoke-pull` job validates the published artifact on both platforms.
- Switches `config/docker-compose.yml` from `build:` to `image: ghcr.io/mcarmody/karakos:${KARAKOS_VERSION:-latest}` so installs just run `docker compose pull`.
- Adds `config/docker-compose.dev.yml` overlay that re-adds `build:` for contributors iterating on the Dockerfile locally.
- Extends `ci.yml` compose-check to validate the dev overlay alongside the main file.
- Updates docs: QUICKSTART (pull-not-build, version pinning), UPGRADING (pull-based upgrade path + rollback), EXTENDING (new "Local development build" section), README (install description).

## Notes

- arm64 pre-flight build not run locally — behavioral pattern prohibits running builds on Mike's hardware. The Dockerfile already has `build-essential` to handle native aarch64 compilation and the CRLF fix from #69. The CI `docker-smoke` job validates amd64. First arm64 validation happens on the first `release.yml` run.
- v1.3 backfill via `workflow_dispatch` is a post-merge manual step from the Actions UI with `ref: v1.3`.

## Test plan

- [ ] `compose-check` CI job passes (validates both `docker-compose.yml` and the dev overlay)
- [ ] `docker-smoke` CI job still passes (build-based smoke on PRs is preserved)
- [ ] After merge: push `v*` tag or fire `workflow_dispatch` with `ref: v1.3` — confirm image appears at `ghcr.io/mcarmody/karakos:v1.3`, `v1`, `latest`
- [ ] `docker pull ghcr.io/mcarmody/karakos:latest` succeeds without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)