### PR TITLE
feat: preflight script — 8 host-state checks before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,26 @@ jobs:
       - name: Verify Node.js installed
         run: docker run --rm --entrypoint node karakos-test:smoke --version
 
+  # Preflight script — tests bin/preflight.sh check logic via Python test suite
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: pip install pytest
+
+      - name: Verify preflight.sh syntax
+        run: bash -n bin/preflight.sh
+
+      - name: Run preflight test suite
+        run: pytest tests/test_preflight.py -v -m "not slow" --tb=short
+
   # Docker Compose validation
   compose-check:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install preflight help
+
+## install: Run preflight checks then pull and start the containers.
+install:
+	./bin/preflight.sh && docker compose pull && docker compose up -d
+
+## preflight: Run host state checks without starting anything.
+preflight:
+	./bin/preflight.sh
+
+## help: List available targets.
+help:
+	@grep -E '^## ' Makefile | sed 's/^## //'

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+# bin/preflight.sh — Pre-install host state checks for Karakos
+#
+# Usage:
+#   ./bin/preflight.sh [--json] [--quiet]
+#
+# Exits 0 if all checks pass (warnings do not affect the exit code).
+# Exits 1 if any check fails.
+#
+# See docs/QUICKSTART.md and Makefile for integration into the install path.
+
+set -uo pipefail
+
+# =============================================================================
+# Working-directory anchoring
+# Allows the script to be called from any cwd, e.g.:
+#   bash /abs/path/to/karakos-package/bin/preflight.sh
+# PREFLIGHT_REPO_ROOT may be overridden for testing.
+# =============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${PREFLIGHT_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+cd "$REPO_ROOT"
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+JSON_MODE=false
+QUIET_MODE=false
+
+for _arg in "$@"; do
+    case "$_arg" in
+        --json)  JSON_MODE=true  ;;
+        --quiet) QUIET_MODE=true ;;
+    esac
+done
+
+# =============================================================================
+# Color setup — only emit ANSI codes when stdout is a real TTY
+# =============================================================================
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+    C_GREEN="$(tput setaf 2)"
+    C_YELLOW="$(tput setaf 3)"
+    C_RED="$(tput setaf 1)"
+    C_RESET="$(tput sgr0)"
+else
+    C_GREEN=""
+    C_YELLOW=""
+    C_RED=""
+    C_RESET=""
+fi
+
+# =============================================================================
+# Result accumulation
+# =============================================================================
+declare -a _NAMES=()
+declare -a _STATUSES=()
+declare -a _REASONS=()
+_FAILURES=0
+_WARNINGS=0
+
+# =============================================================================
+# Output helpers
+# =============================================================================
+_pass() {
+    local name="$1"
+    _NAMES+=("$name")
+    _STATUSES+=("pass")
+    _REASONS+=("null")
+    if [ "$JSON_MODE" = false ] && [ "$QUIET_MODE" = false ]; then
+        printf '%s✓ %s%s\n' "$C_GREEN" "$name" "$C_RESET"
+    fi
+}
+
+_warn() {
+    local name="$1" reason="$2" remediation="$3"
+    _NAMES+=("$name")
+    _STATUSES+=("warn")
+    _REASONS+=("$reason")
+    _WARNINGS=$((_WARNINGS + 1))
+    if [ "$JSON_MODE" = false ]; then
+        printf '%s⚠ %s: %s%s\n' "$C_YELLOW" "$name" "$reason" "$C_RESET"
+        printf '  %s\n' "$remediation"
+    fi
+}
+
+_fail() {
+    local name="$1" reason="$2" remediation="$3"
+    _NAMES+=("$name")
+    _STATUSES+=("fail")
+    _REASONS+=("$reason")
+    _FAILURES=$((_FAILURES + 1))
+    if [ "$JSON_MODE" = false ]; then
+        printf '%s✗ %s: %s%s\n' "$C_RED" "$name" "$reason" "$C_RESET"
+        printf '  %s\n' "$remediation"
+    fi
+}
+
+# =============================================================================
+# Check 1: docker_engine_reachable
+# Use timeout 10 so a hung Docker socket doesn't make preflight itself hang.
+# =============================================================================
+_check_docker_engine_reachable() {
+    timeout 10 docker info >/dev/null 2>&1
+    local rc=$?
+    if [ "$rc" -eq 0 ]; then
+        _pass "docker_engine_reachable"
+    elif [ "$rc" -eq 124 ]; then
+        _fail "docker_engine_reachable" \
+            "Docker engine reachable but unresponsive (timed out after 10s). Docker Desktop may be mid-start, the daemon may be hung, or the socket may be wedged." \
+            "Restart Docker Desktop / \`sudo systemctl restart docker\`."
+    else
+        _fail "docker_engine_reachable" \
+            "Docker engine not reachable." \
+            "Install Docker Desktop (Windows/macOS) or docker-engine (Linux): https://docs.docker.com/get-docker/"
+    fi
+}
+
+# =============================================================================
+# Check 2: docker_compose_v2
+# =============================================================================
+_check_docker_compose_v2() {
+    local version_output
+    version_output="$(docker compose version 2>/dev/null)" || {
+        _fail "docker_compose_v2" \
+            "Docker Compose v2 not found." \
+            "Update Docker Desktop, or install the compose-plugin package on Linux."
+        return
+    }
+
+    # Parse e.g. "Docker Compose version v2.27.0"
+    local version_str major
+    version_str="$(printf '%s' "$version_output" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    major="$(printf '%s' "$version_str" | grep -oE '^v?[0-9]+' | tr -d 'v')"
+
+    if [ -z "$major" ] || ! [ "$major" -ge 2 ] 2>/dev/null; then
+        _fail "docker_compose_v2" \
+            "Docker Compose v2 not found (found: ${version_str:-unknown})." \
+            "Update Docker Desktop, or install the compose-plugin package on Linux."
+    else
+        _pass "docker_compose_v2"
+    fi
+}
+
+# =============================================================================
+# Check 3: wsl_integration_healthy  (only runs inside WSL)
+# Use timeout 10 here too — same rationale as check 1.
+# =============================================================================
+_check_wsl_integration_healthy() {
+    [ -n "${WSL_DISTRO_NAME:-}" ] || return 0
+
+    local docker_out rc
+    docker_out="$(timeout 10 docker info 2>&1)"
+    rc=$?
+
+    if [ "$rc" -eq 124 ]; then
+        _fail "wsl_integration_healthy" \
+            "Docker reachable but unresponsive from WSL (timed out)." \
+            "Restart Docker Desktop and re-toggle WSL integration."
+    elif [ "$rc" -ne 0 ] || printf '%s' "$docker_out" | grep -qE "Permission denied|WSL distro is not running"; then
+        _fail "wsl_integration_healthy" \
+            "Docker Desktop's WSL integration is not running for this distro." \
+            "Open Docker Desktop → Settings → Resources → WSL Integration, toggle ${WSL_DISTRO_NAME} off, apply, toggle on, apply."
+    else
+        _pass "wsl_integration_healthy"
+    fi
+}
+
+# =============================================================================
+# Check 4: architecture_supported
+# =============================================================================
+_check_architecture_supported() {
+    local arch
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64|aarch64|arm64)
+            _pass "architecture_supported"
+            ;;
+        *)
+            _fail "architecture_supported" \
+                "Unsupported architecture: ${arch}. Karakos images are published for amd64 and arm64 only." \
+                "Use an x86_64 or arm64 machine."
+            ;;
+    esac
+}
+
+# =============================================================================
+# Check 5: shell_script_line_endings
+# Belt-and-suspenders alongside .gitattributes — catches clones made before
+# the LF-enforcement fix landed or with core.autocrlf=true on Windows.
+# =============================================================================
+_check_shell_script_line_endings() {
+    local crlf_files=()
+    local f
+
+    for f in "$REPO_ROOT"/bin/*.sh "$REPO_ROOT/bin/kara"; do
+        [ -f "$f" ] || continue
+        if file "$f" 2>/dev/null | grep -q "CRLF line terminators"; then
+            crlf_files+=("$(basename "$f")")
+        fi
+    done
+
+    if [ "${#crlf_files[@]}" -gt 0 ]; then
+        local files_list
+        files_list="${crlf_files[*]}"
+        _fail "shell_script_line_endings" \
+            "${files_list} has Windows line endings." \
+            "Run: git config core.autocrlf input && git rm --cached -r . && git reset --hard. Or: dos2unix bin/*.sh bin/kara."
+    else
+        _pass "shell_script_line_endings"
+    fi
+}
+
+# =============================================================================
+# .env parser helpers
+#
+# Reads config/.env line-by-line WITHOUT source/eval — no arbitrary code exec.
+# Handles:
+#   DASHBOARD_PORT=3000
+#   export DASHBOARD_PORT=3000
+#   declare -x DASHBOARD_PORT=3000
+#   DASHBOARD_PORT="3000"   (double-quoted)
+#   DASHBOARD_PORT='3000'   (single-quoted)
+# Skips blank lines and comments.
+#
+# Cross-reference: required_vars list mirrors bin/entrypoint.sh.
+# If entrypoint.sh adds new required vars, update _REQUIRED_VARS below too.
+# =============================================================================
+_parse_env_value() {
+    local target="$1" env_file="$2"
+    local line name value
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Strip leading spaces and tabs
+        line="${line#"${line%%[!	 ]*}"}"
+
+        # Skip blank lines and comments
+        [[ -z "$line" || "$line" == \#* ]] && continue
+
+        # Strip optional prefixes
+        line="${line#export }"
+        line="${line#declare -x }"
+
+        # Split on first '='
+        name="${line%%=*}"
+        value="${line#*=}"
+
+        # Strip surrounding double or single quotes from value
+        if [[ "$value" == \"*\" ]]; then
+            value="${value#\"}"
+            value="${value%\"}"
+        elif [[ "$value" == \'*\' ]]; then
+            value="${value#\'}"
+            value="${value%\'}"
+        fi
+
+        if [[ "$name" == "$target" && -n "$value" ]]; then
+            printf '%s' "$value"
+            return 0
+        fi
+    done < "$env_file"
+
+    return 1
+}
+
+# Returns 0 if any variable matching the glob pattern has a non-empty value.
+# shellcheck disable=SC2254
+_env_has_pattern() {
+    local pattern="$1" env_file="$2"
+    local line name value
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line#"${line%%[!	 ]*}"}"
+        [[ -z "$line" || "$line" == \#* ]] && continue
+
+        line="${line#export }"
+        line="${line#declare -x }"
+
+        name="${line%%=*}"
+        value="${line#*=}"
+
+        if [[ "$value" == \"*\" ]]; then
+            value="${value#\"}"
+            value="${value%\"}"
+        elif [[ "$value" == \'*\' ]]; then
+            value="${value#\'}"
+            value="${value%\'}"
+        fi
+
+        if [[ "$name" == $pattern && -n "$value" ]]; then
+            return 0
+        fi
+    done < "$env_file"
+
+    return 1
+}
+
+# =============================================================================
+# Check 6: required_env_vars
+# Required vars mirror bin/entrypoint.sh — update both if requirements change.
+# =============================================================================
+_REQUIRED_VARS=("DASHBOARD_PORT" "AGENT_SERVER_TOKEN")
+_ENV_FILE="$REPO_ROOT/config/.env"
+_PARSED_DASHBOARD_PORT=""
+
+_check_required_env_vars() {
+    if [ ! -f "$_ENV_FILE" ]; then
+        _fail "required_env_vars" \
+            "config/.env missing or incomplete. Required: DASHBOARD_PORT, AGENT_SERVER_TOKEN, at least one DISCORD_TOKEN_*." \
+            "See config/.env.template."
+        return
+    fi
+
+    local all_ok=true var val
+
+    for var in "${_REQUIRED_VARS[@]}"; do
+        val="$(_parse_env_value "$var" "$_ENV_FILE")" || true
+        if [ -z "$val" ]; then
+            all_ok=false
+        elif [ "$var" = "DASHBOARD_PORT" ]; then
+            _PARSED_DASHBOARD_PORT="$val"
+        fi
+    done
+
+    # At least one Discord token must be present.
+    # Matches DISCORD_BOT_TOKEN_PRIMARY, DISCORD_TOKEN_RELAY, etc.
+    if ! _env_has_pattern "*DISCORD*TOKEN*" "$_ENV_FILE"; then
+        all_ok=false
+    fi
+
+    if [ "$all_ok" = false ]; then
+        _fail "required_env_vars" \
+            "config/.env missing or incomplete. Required: DASHBOARD_PORT, AGENT_SERVER_TOKEN, at least one DISCORD_TOKEN_*." \
+            "See config/.env.template."
+    else
+        _pass "required_env_vars"
+    fi
+}
+
+# =============================================================================
+# Check 7: port_available
+# Skipped if required_env_vars failed (no DASHBOARD_PORT to check).
+# =============================================================================
+_check_port_available() {
+    [ -n "$_PARSED_DASHBOARD_PORT" ] || return 0
+
+    local port="$_PARSED_DASHBOARD_PORT" in_use=false
+
+    if command -v ss >/dev/null 2>&1; then
+        ss -lnt 2>/dev/null | grep -q ":${port} " && in_use=true
+    elif command -v lsof >/dev/null 2>&1; then
+        lsof -i ":${port}" >/dev/null 2>&1 && in_use=true
+    fi
+
+    if [ "$in_use" = true ]; then
+        _fail "port_available" \
+            "Port ${port} is already in use on this host." \
+            "Change DASHBOARD_PORT in config/.env or stop the conflicting service."
+    else
+        _pass "port_available"
+    fi
+}
+
+# =============================================================================
+# Check 8: disk_space
+# Warn below 10GB, fail below 5GB.
+# Uses timeout 10 on docker info per the spec requirement.
+# Skipped gracefully if Docker is not running (already caught by check 1).
+# =============================================================================
+_check_disk_space() {
+    local docker_root
+    docker_root="$(timeout 10 docker info 2>/dev/null | grep "Docker Root Dir" | awk '{print $NF}')"
+
+    if [ -z "$docker_root" ]; then
+        # Docker unreachable — already reported by docker_engine_reachable.
+        # Don't add noise by repeating the failure here.
+        return
+    fi
+
+    local free_gb
+    free_gb="$(df -BG "$docker_root" 2>/dev/null | awk 'NR==2 {gsub("G",""); print $4}')"
+
+    if [ -z "$free_gb" ]; then
+        _warn "disk_space" \
+            "Could not determine free disk space for Docker root (${docker_root})." \
+            "Run: df -h ${docker_root}"
+        return
+    fi
+
+    if [ "$free_gb" -lt 5 ]; then
+        _fail "disk_space" \
+            "Less than 5GB free in Docker root. Image + dashboard layer is ~3-4GB." \
+            "Free space or move Docker root."
+    elif [ "$free_gb" -lt 10 ]; then
+        _warn "disk_space" \
+            "Low disk space (${free_gb}GB free). Install will succeed but you'll have little headroom for logs and data." \
+            "Consider freeing up space before proceeding."
+    else
+        _pass "disk_space"
+    fi
+}
+
+# =============================================================================
+# Run all checks unconditionally
+# =============================================================================
+_check_docker_engine_reachable
+_check_docker_compose_v2
+_check_wsl_integration_healthy
+_check_architecture_supported
+_check_shell_script_line_endings
+_check_required_env_vars
+_check_port_available
+_check_disk_space
+
+# =============================================================================
+# Final output
+# =============================================================================
+if [ "$JSON_MODE" = true ]; then
+    n="${#_NAMES[@]}"
+    printf '{\n'
+    printf '  "checks": [\n'
+    for (( i = 0; i < n; i++ )); do
+        name="${_NAMES[$i]}"
+        status="${_STATUSES[$i]}"
+        reason="${_REASONS[$i]}"
+
+        if [ "$reason" = "null" ]; then
+            reason_json="null"
+        else
+            reason_esc="${reason//\"/\\\"}"
+            reason_json="\"${reason_esc}\""
+        fi
+
+        if [ $(( i + 1 )) -lt "$n" ]; then
+            comma=","
+        else
+            comma=""
+        fi
+        printf '    {"name": "%s", "status": "%s", "reason": %s}%s\n' \
+            "$name" "$status" "$reason_json" "$comma"
+    done
+    printf '  ],\n'
+
+    if [ "$_FAILURES" -gt 0 ]; then pass_val="false"; else pass_val="true"; fi
+
+    printf '  "pass": %s,\n'     "$pass_val"
+    printf '  "warnings": %d,\n' "$_WARNINGS"
+    printf '  "failures": %d\n'  "$_FAILURES"
+    printf '}\n'
+else
+    printf '\n'
+    if [ "$_FAILURES" -gt 0 ]; then
+        printf '%sPreflight: FAIL — %d issue(s) above%s\n' "$C_RED" "$_FAILURES" "$C_RESET"
+    elif [ "$_WARNINGS" -gt 0 ]; then
+        printf '%sPreflight: PASS (%d warning(s))%s\n' "$C_GREEN" "$_WARNINGS" "$C_RESET"
+    else
+        printf '%sPreflight: PASS%s\n' "$C_GREEN" "$C_RESET"
+    fi
+fi
+
+if [ "$_FAILURES" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -349,6 +349,11 @@ _check_port_available() {
         ss -lnt 2>/dev/null | grep -q ":${port} " && in_use=true
     elif command -v lsof >/dev/null 2>&1; then
         lsof -i ":${port}" >/dev/null 2>&1 && in_use=true
+    else
+        _warn "port_available" \
+            "Cannot check port ${port}: neither ss nor lsof is installed." \
+            "Install iproute2 (ss) or lsof, or verify manually: lsof -i :${port}"
+        return
     fi
 
     if [ "$in_use" = true ]; then

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -38,10 +38,22 @@ The wizard saves progress, so you can quit and resume with `./setup.sh`.
 
 ## Start
 
+Run the preflight check first to catch Docker/WSL issues before they surface
+deep inside the install:
+
 ```bash
-docker compose pull
-docker compose up -d
+./bin/preflight.sh && docker compose pull && docker compose up -d
 ```
+
+Or use the convenience target:
+
+```bash
+make install
+```
+
+`make install` runs preflight, pulls the prebuilt image, and starts the
+containers. If preflight fails it halts with a clear error — fix the issue
+flagged and re-run.
 
 `docker compose pull` downloads the prebuilt multi-arch image from GHCR (~1.2 GB).
 No local build step — startup is fast once the image is on disk.

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -477,6 +477,16 @@ class TestPortAvailable:
         assert "already in use" in result.stdout
         assert "3000" in result.stdout
 
+    def test_no_port_check_tools_warns(self, tmp_path):
+        """When neither ss nor lsof is available, emit warn instead of silently passing."""
+        mock = make_full_mock_bin(tmp_path, port_in_use=None)
+        (mock / "ss").unlink()  # Remove ss; lsof was never added
+        # Restrict PATH to mock_bin only so system ss/lsof cannot leak in
+        result = run(tmp_path, mock, extra_env={"PATH": str(mock)})
+        assert result.returncode == 0  # warn, not fail
+        assert "⚠ port_available" in result.stdout
+        assert "neither ss nor lsof" in result.stdout
+
 
 # =============================================================================
 # Check 8: disk_space

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,662 @@
+"""
+Tests for bin/preflight.sh
+
+Strategy:
+  - Point PREFLIGHT_REPO_ROOT at a tmp directory so each test controls
+    config/.env without touching the real repo.
+  - Prepend a mock_bin directory to PATH to stub out docker, uname, file,
+    ss, df, and other system commands.
+  - Run the script with subprocess and assert exit code / stdout.
+
+Slow tests (those that intentionally trigger the 10-second timeout) are marked
+@pytest.mark.slow and excluded from the default pytest run via:
+    pytest tests/ -m "not slow"
+"""
+
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).parent.parent
+PREFLIGHT = PACKAGE_ROOT / "bin" / "preflight.sh"
+
+# Minimal valid .env content for tests that don't care about env-var specifics.
+VALID_ENV = textwrap.dedent("""\
+    DASHBOARD_PORT=3000
+    AGENT_SERVER_TOKEN=test-token
+    DISCORD_BOT_TOKEN_PRIMARY=test-discord-token
+""")
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def write_mock(bin_dir: Path, name: str, content: str) -> Path:
+    """Write an executable mock script."""
+    p = bin_dir / name
+    p.write_text(content)
+    p.chmod(0o755)
+    return p
+
+
+def make_standard_docker(bin_dir: Path, *, compose_version: str = "v2.27.0",
+                          docker_root: str = "/var/lib/docker") -> None:
+    """Write a mock docker that passes all checks."""
+    write_mock(bin_dir, "docker", f"""\
+#!/bin/bash
+if [ "$1" = "info" ]; then
+    echo "Docker Root Dir: {docker_root}"
+    exit 0
+elif [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+    echo "Docker Compose version {compose_version}"
+    exit 0
+fi
+exit 0
+""")
+
+
+def make_standard_df(bin_dir: Path, free_gb: int = 50) -> None:
+    """Write a mock df that reports the given free GB."""
+    write_mock(bin_dir, "df", f"""\
+#!/bin/bash
+echo "Filesystem      1G-blocks  Used Available Use% Mounted on"
+echo "/dev/sda1             100    50      {free_gb}G  50% /"
+""")
+
+
+def make_standard_ss(bin_dir: Path, *, port_in_use: int | None = None) -> None:
+    """Write a mock ss. If port_in_use is set, that port appears as listening."""
+    if port_in_use is not None:
+        write_mock(bin_dir, "ss", f"""\
+#!/bin/bash
+echo "Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port"
+echo "tcp   LISTEN 0      128   0.0.0.0:{port_in_use} 0.0.0.0:*"
+""")
+    else:
+        write_mock(bin_dir, "ss", """\
+#!/bin/bash
+echo "Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port"
+""")
+
+
+def make_standard_file(bin_dir: Path, *, crlf_file: str | None = None) -> None:
+    """Write a mock 'file' command. If crlf_file is given, that basename gets CRLF output."""
+    write_mock(bin_dir, "file", f"""\
+#!/bin/bash
+base="$(basename "$1")"
+if [ "$base" = "{crlf_file or '__no_crlf__'}" ]; then
+    echo "$1: Bourne-Again shell script, ASCII text executable, with CRLF line terminators"
+else
+    echo "$1: Bourne-Again shell script, ASCII text executable"
+fi
+""")
+
+
+def make_full_mock_bin(tmp_path: Path, **kwargs) -> Path:
+    """
+    Create a mock_bin directory pre-populated with passing stubs.
+
+    Keyword overrides:
+      compose_version (str)   — docker compose version string
+      docker_root (str)       — Docker Root Dir reported by docker info
+      disk_free_gb (int)      — free GB reported by df
+      port_in_use (int|None)  — port reported as in use by ss
+      crlf_file (str|None)    — basename of file to report as CRLF
+    """
+    bin_dir = tmp_path / "mock_bin"
+    bin_dir.mkdir(exist_ok=True)
+
+    compose_version = kwargs.get("compose_version", "v2.27.0")
+    docker_root = kwargs.get("docker_root", "/var/lib/docker")
+    disk_free_gb = kwargs.get("disk_free_gb", 50)
+    port_in_use = kwargs.get("port_in_use", None)
+    crlf_file = kwargs.get("crlf_file", None)
+
+    make_standard_docker(bin_dir, compose_version=compose_version, docker_root=docker_root)
+    make_standard_df(bin_dir, free_gb=disk_free_gb)
+    make_standard_ss(bin_dir, port_in_use=port_in_use)
+    make_standard_file(bin_dir, crlf_file=crlf_file)
+
+    # uname always returns x86_64 unless overridden
+    write_mock(bin_dir, "uname", """\
+#!/bin/bash
+if [ "$1" = "-m" ]; then echo "x86_64"; else /usr/bin/uname "$@"; fi
+""")
+
+    return bin_dir
+
+
+def run(tmp_path: Path, mock_bin: Path | None = None,
+        args: list[str] | None = None,
+        env_content: str | None = VALID_ENV,
+        extra_env: dict | None = None,
+        cwd: str | None = None) -> subprocess.CompletedProcess:
+    """
+    Run preflight.sh.
+
+    - Creates config/.env in a temp repo root (PREFLIGHT_REPO_ROOT).
+    - Prepends mock_bin to PATH if provided.
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    (repo_root / "config").mkdir(exist_ok=True)
+    (repo_root / "bin").mkdir(exist_ok=True)
+
+    if env_content is not None:
+        (repo_root / "config" / ".env").write_text(env_content)
+
+    # Create a minimal shell script in the temp repo so the line-endings check
+    # has something to inspect (the glob bin/*.sh would otherwise be empty).
+    (repo_root / "bin" / "entrypoint.sh").write_text("#!/bin/bash\necho hello\n")
+
+    env = os.environ.copy()
+    env.pop("WSL_DISTRO_NAME", None)  # Never run WSL check unless test explicitly sets it
+    env["PREFLIGHT_REPO_ROOT"] = str(repo_root)
+
+    if mock_bin is not None:
+        env["PATH"] = f"{mock_bin}:{env.get('PATH', '/usr/bin:/bin')}"
+
+    if extra_env:
+        env.update(extra_env)
+
+    cmd = ["bash", str(PREFLIGHT)] + (args or [])
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd or str(PACKAGE_ROOT),
+        timeout=60,
+    )
+
+
+# =============================================================================
+# Check 1: docker_engine_reachable
+# =============================================================================
+
+class TestDockerEngineReachable:
+    def test_docker_ok(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock)
+        assert "✓ docker_engine_reachable" in result.stdout or result.returncode == 0
+        assert "docker_engine_reachable" in result.stdout
+
+    def test_docker_not_reachable(self, tmp_path):
+        """docker exits with non-zero (simulating not installed / not reachable)."""
+        mock = make_full_mock_bin(tmp_path)
+        # exit 127 is how bash signals "command not found"; any non-0 non-124 triggers
+        # the "not reachable" branch in the script.
+        write_mock(mock, "docker", "#!/bin/bash\nexit 127\n")
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "docker_engine_reachable" in result.stdout
+        assert "not reachable" in result.stdout
+
+    def test_docker_exits_nonzero(self, tmp_path):
+        """docker info exits non-zero (not timeout) → not-reachable message."""
+        mock = make_full_mock_bin(tmp_path)
+        write_mock(mock, "docker", """\
+#!/bin/bash
+if [ "$1" = "info" ]; then exit 1; fi
+echo "Docker Compose version v2.27.0"
+""")
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "not reachable" in result.stdout
+
+    @pytest.mark.slow
+    def test_docker_info_hangs(self, tmp_path):
+        """docker info hangs → fail with 'timed out' message after ~10s."""
+        mock = make_full_mock_bin(tmp_path)
+        write_mock(mock, "docker", """\
+#!/bin/bash
+if [ "$1" = "info" ]; then
+    sleep 30
+fi
+echo "Docker Compose version v2.27.0"
+""")
+        result = run(tmp_path, mock, cwd="/tmp")
+        assert result.returncode == 1
+        assert "timed out" in result.stdout
+
+
+# =============================================================================
+# Check 2: docker_compose_v2
+# =============================================================================
+
+class TestDockerComposeV2:
+    def test_compose_v2_pass(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock)
+        assert "✓ docker_compose_v2" in result.stdout
+
+    def test_compose_not_found(self, tmp_path):
+        """docker compose subcommand not found → fail."""
+        mock = make_full_mock_bin(tmp_path)
+        write_mock(mock, "docker", """\
+#!/bin/bash
+if [ "$1" = "info" ]; then
+    echo "Docker Root Dir: /var/lib/docker"
+    exit 0
+elif [ "$1" = "compose" ]; then
+    exit 1
+fi
+""")
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "docker_compose_v2" in result.stdout
+        assert "not found" in result.stdout
+
+    def test_compose_v1_fails(self, tmp_path):
+        """Docker Compose v1.x is reported → fail."""
+        mock = make_full_mock_bin(tmp_path, compose_version="1.29.2")
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "docker_compose_v2" in result.stdout
+        assert "not found" in result.stdout
+
+
+# =============================================================================
+# Check 3: wsl_integration_healthy
+# =============================================================================
+
+class TestWslIntegrationHealthy:
+    def test_no_wsl_distro_name_skips_check(self, tmp_path):
+        """Without WSL_DISTRO_NAME, the check doesn't run."""
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock)
+        assert "wsl_integration_healthy" not in result.stdout
+
+    def test_wsl_healthy(self, tmp_path):
+        """Inside WSL with healthy docker → pass."""
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, extra_env={"WSL_DISTRO_NAME": "Ubuntu"})
+        assert "✓ wsl_integration_healthy" in result.stdout
+
+    def test_wsl_permission_denied(self, tmp_path):
+        """docker info outputs 'Permission denied' → WSL integration fail."""
+        mock = make_full_mock_bin(tmp_path)
+        write_mock(mock, "docker", """\
+#!/bin/bash
+if [ "$1" = "info" ]; then
+    echo "Cannot connect to the Docker daemon. Permission denied."
+    exit 1
+elif [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+    echo "Docker Compose version v2.27.0"
+    exit 0
+fi
+""")
+        result = run(tmp_path, mock, extra_env={"WSL_DISTRO_NAME": "Ubuntu"})
+        assert result.returncode == 1
+        assert "wsl_integration_healthy" in result.stdout
+        assert "WSL integration" in result.stdout
+
+    @pytest.mark.slow
+    def test_wsl_timeout(self, tmp_path):
+        """docker info hangs inside WSL → wsl timeout fail."""
+        mock = make_full_mock_bin(tmp_path)
+        write_mock(mock, "docker", """\
+#!/bin/bash
+if [ "$1" = "info" ]; then
+    sleep 30
+elif [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+    echo "Docker Compose version v2.27.0"
+    exit 0
+fi
+""")
+        result = run(tmp_path, mock, extra_env={"WSL_DISTRO_NAME": "Ubuntu"})
+        assert result.returncode == 1
+        assert "wsl_integration_healthy" in result.stdout
+        assert "timed out" in result.stdout
+
+
+# =============================================================================
+# Check 4: architecture_supported
+# =============================================================================
+
+class TestArchitectureSupported:
+    @pytest.mark.parametrize("arch", ["x86_64", "aarch64", "arm64"])
+    def test_supported_arch_passes(self, tmp_path, arch):
+        mock = make_full_mock_bin(tmp_path)
+        write_mock(mock, "uname", f"""\
+#!/bin/bash
+if [ "$1" = "-m" ]; then echo "{arch}"; else /usr/bin/uname "$@"; fi
+""")
+        result = run(tmp_path, mock)
+        assert "✓ architecture_supported" in result.stdout
+
+    def test_unsupported_arch_fails(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        write_mock(mock, "uname", """\
+#!/bin/bash
+if [ "$1" = "-m" ]; then echo "riscv64"; else /usr/bin/uname "$@"; fi
+""")
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "Unsupported architecture: riscv64" in result.stdout
+
+
+# =============================================================================
+# Check 5: shell_script_line_endings
+# =============================================================================
+
+class TestShellScriptLineEndings:
+    def test_no_crlf_passes(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock)
+        assert "✓ shell_script_line_endings" in result.stdout
+
+    def test_crlf_script_fails(self, tmp_path):
+        """A shell script with CRLF → fail with line-endings message."""
+        mock = make_full_mock_bin(tmp_path, crlf_file="entrypoint.sh")
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "shell_script_line_endings" in result.stdout
+        assert "Windows line endings" in result.stdout
+
+    def test_crlf_message_contains_filename(self, tmp_path):
+        """Failure message names the problematic file."""
+        mock = make_full_mock_bin(tmp_path, crlf_file="entrypoint.sh")
+        result = run(tmp_path, mock)
+        assert "entrypoint.sh" in result.stdout
+
+
+# =============================================================================
+# Check 6: required_env_vars + .env parser
+# =============================================================================
+
+class TestRequiredEnvVars:
+    def test_all_vars_present_passes(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock)
+        assert "✓ required_env_vars" in result.stdout
+
+    def test_missing_env_file(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, env_content=None)
+        assert result.returncode == 1
+        assert "required_env_vars" in result.stdout
+        assert "missing or incomplete" in result.stdout
+
+    def test_missing_dashboard_port(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        env = "AGENT_SERVER_TOKEN=tok\nDISCORD_BOT_TOKEN_PRIMARY=dt\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert result.returncode == 1
+        assert "required_env_vars" in result.stdout
+
+    def test_missing_agent_server_token(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        env = "DASHBOARD_PORT=3000\nDISCORD_BOT_TOKEN_PRIMARY=dt\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert result.returncode == 1
+        assert "required_env_vars" in result.stdout
+
+    def test_missing_discord_token(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        env = "DASHBOARD_PORT=3000\nAGENT_SERVER_TOKEN=tok\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert result.returncode == 1
+        assert "required_env_vars" in result.stdout
+
+    # --- Parser-specific cases ---
+
+    def test_plain_assignment(self, tmp_path):
+        """DASHBOARD_PORT=3000 → matches."""
+        mock = make_full_mock_bin(tmp_path)
+        env = "DASHBOARD_PORT=3000\nAGENT_SERVER_TOKEN=tok\nDISCORD_BOT_TOKEN_PRIMARY=dt\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert "✓ required_env_vars" in result.stdout
+
+    def test_export_prefix_stripped(self, tmp_path):
+        """export DASHBOARD_PORT=3000 → matches."""
+        mock = make_full_mock_bin(tmp_path)
+        env = "export DASHBOARD_PORT=3000\nexport AGENT_SERVER_TOKEN=tok\nexport DISCORD_BOT_TOKEN_PRIMARY=dt\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert "✓ required_env_vars" in result.stdout
+
+    def test_declare_prefix_stripped(self, tmp_path):
+        """declare -x DASHBOARD_PORT=3000 → matches."""
+        mock = make_full_mock_bin(tmp_path)
+        env = "declare -x DASHBOARD_PORT=3000\ndeclare -x AGENT_SERVER_TOKEN=tok\ndeclare -x DISCORD_BOT_TOKEN_PRIMARY=dt\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert "✓ required_env_vars" in result.stdout
+
+    def test_double_quoted_value_stripped(self, tmp_path):
+        """DASHBOARD_PORT="3000" → matches."""
+        mock = make_full_mock_bin(tmp_path)
+        env = 'DASHBOARD_PORT="3000"\nAGENT_SERVER_TOKEN="tok"\nDISCORD_BOT_TOKEN_PRIMARY="dt"\n'
+        result = run(tmp_path, mock, env_content=env)
+        assert "✓ required_env_vars" in result.stdout
+
+    def test_single_quoted_value_stripped(self, tmp_path):
+        """DASHBOARD_PORT='3000' → matches."""
+        mock = make_full_mock_bin(tmp_path)
+        env = "DASHBOARD_PORT='3000'\nAGENT_SERVER_TOKEN='tok'\nDISCORD_BOT_TOKEN_PRIMARY='dt'\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert "✓ required_env_vars" in result.stdout
+
+    def test_comment_line_not_matched(self, tmp_path):
+        """# DASHBOARD_PORT=3000 (comment) → treated as missing."""
+        mock = make_full_mock_bin(tmp_path)
+        env = "# DASHBOARD_PORT=3000\nAGENT_SERVER_TOKEN=tok\nDISCORD_BOT_TOKEN_PRIMARY=dt\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert result.returncode == 1
+        assert "required_env_vars" in result.stdout
+
+    def test_empty_value_not_matched(self, tmp_path):
+        """DASHBOARD_PORT= (empty) → treated as missing."""
+        mock = make_full_mock_bin(tmp_path)
+        env = "DASHBOARD_PORT=\nAGENT_SERVER_TOKEN=tok\nDISCORD_BOT_TOKEN_PRIMARY=dt\n"
+        result = run(tmp_path, mock, env_content=env)
+        assert result.returncode == 1
+        assert "required_env_vars" in result.stdout
+
+
+# =============================================================================
+# Check 7: port_available
+# =============================================================================
+
+class TestPortAvailable:
+    def test_port_free_passes(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path, port_in_use=None)
+        result = run(tmp_path, mock)
+        assert "✓ port_available" in result.stdout
+
+    def test_port_in_use_fails(self, tmp_path):
+        """Port 3000 reported as in use → fail."""
+        mock = make_full_mock_bin(tmp_path, port_in_use=3000)
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "port_available" in result.stdout
+        assert "already in use" in result.stdout
+        assert "3000" in result.stdout
+
+
+# =============================================================================
+# Check 8: disk_space
+# =============================================================================
+
+class TestDiskSpace:
+    def test_abundant_disk_passes(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path, disk_free_gb=50)
+        result = run(tmp_path, mock)
+        assert "✓ disk_space" in result.stdout
+
+    def test_low_disk_warns(self, tmp_path):
+        """Between 5–10GB free → warn, exit 0."""
+        mock = make_full_mock_bin(tmp_path, disk_free_gb=8)
+        result = run(tmp_path, mock)
+        assert result.returncode == 0
+        assert "⚠ disk_space" in result.stdout
+        assert "PASS (1 warning(s))" in result.stdout
+
+    def test_insufficient_disk_fails(self, tmp_path):
+        """Less than 5GB free → fail, exit 1."""
+        mock = make_full_mock_bin(tmp_path, disk_free_gb=3)
+        result = run(tmp_path, mock)
+        assert result.returncode == 1
+        assert "✗ disk_space" in result.stdout
+        assert "Less than 5GB" in result.stdout
+
+
+# =============================================================================
+# Exit code and summary line
+# =============================================================================
+
+class TestExitCodeAndSummary:
+    def test_all_pass_exit_0(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock)
+        assert result.returncode == 0
+        assert "Preflight: PASS" in result.stdout
+
+    def test_warnings_only_exit_0(self, tmp_path):
+        """Warnings alone don't flip the exit code."""
+        mock = make_full_mock_bin(tmp_path, disk_free_gb=8)
+        result = run(tmp_path, mock)
+        assert result.returncode == 0
+        assert "Preflight: PASS (1 warning(s))" in result.stdout
+
+    def test_any_failure_exit_1(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, env_content=None)  # triggers required_env_vars fail
+        assert result.returncode == 1
+        assert "Preflight: FAIL" in result.stdout
+
+
+# =============================================================================
+# --quiet flag
+# =============================================================================
+
+class TestQuietFlag:
+    def test_quiet_suppresses_passes(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--quiet"])
+        # Passing checks should not appear
+        assert "✓ docker_engine_reachable" not in result.stdout
+        assert "✓ architecture_supported" not in result.stdout
+
+    def test_quiet_shows_failures(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--quiet"], env_content=None)
+        assert "required_env_vars" in result.stdout
+        assert result.returncode == 1
+
+    def test_quiet_shows_warnings(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path, disk_free_gb=8)
+        result = run(tmp_path, mock, args=["--quiet"])
+        assert "⚠ disk_space" in result.stdout
+
+    def test_quiet_still_shows_summary(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--quiet"])
+        assert "Preflight: PASS" in result.stdout
+
+
+# =============================================================================
+# --json flag
+# =============================================================================
+
+class TestJsonFlag:
+    def _parse(self, result: subprocess.CompletedProcess) -> dict:
+        assert result.returncode in (0, 1), f"Script crashed:\n{result.stderr}"
+        return json.loads(result.stdout)
+
+    def test_valid_json_all_pass(self, tmp_path):
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--json"])
+        data = self._parse(result)
+        assert isinstance(data["checks"], list)
+        assert data["pass"] is True
+        assert data["warnings"] == 0
+        assert data["failures"] == 0
+
+    def test_json_schema_fields(self, tmp_path):
+        """Each check object has name, status, reason."""
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--json"])
+        data = self._parse(result)
+        for check in data["checks"]:
+            assert "name" in check
+            assert "status" in check
+            assert "reason" in check
+            assert check["status"] in ("pass", "warn", "fail")
+
+    def test_json_pass_status_is_null_reason(self, tmp_path):
+        """Passing checks have reason: null."""
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--json"])
+        data = self._parse(result)
+        for check in data["checks"]:
+            if check["status"] == "pass":
+                assert check["reason"] is None
+
+    def test_json_three_state_warn(self, tmp_path):
+        """Warn case: status=warn, top-level warnings=1, pass=true."""
+        mock = make_full_mock_bin(tmp_path, disk_free_gb=8)
+        result = run(tmp_path, mock, args=["--json"])
+        assert result.returncode == 0
+        data = self._parse(result)
+        assert data["pass"] is True
+        assert data["warnings"] == 1
+        assert data["failures"] == 0
+        warn_checks = [c for c in data["checks"] if c["status"] == "warn"]
+        assert len(warn_checks) == 1
+        assert warn_checks[0]["name"] == "disk_space"
+        assert warn_checks[0]["reason"] is not None
+
+    def test_json_fail_state(self, tmp_path):
+        """Fail case: pass=false, failures>0."""
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--json"], env_content=None)
+        assert result.returncode == 1
+        data = self._parse(result)
+        assert data["pass"] is False
+        assert data["failures"] >= 1
+
+    def test_json_fail_reason_is_string(self, tmp_path):
+        """Failing checks have a non-null reason string."""
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, args=["--json"], env_content=None)
+        data = self._parse(result)
+        fail_checks = [c for c in data["checks"] if c["status"] == "fail"]
+        for check in fail_checks:
+            assert isinstance(check["reason"], str)
+            assert len(check["reason"]) > 0
+
+
+# =============================================================================
+# Working-directory anchoring (BASH_SOURCE)
+# =============================================================================
+
+class TestAnchoring:
+    def test_runs_correctly_from_outside_repo(self, tmp_path):
+        """
+        Script anchors to repo root via BASH_SOURCE, not the caller's cwd.
+        Run from /tmp (not the repo); the script must still find config/.env
+        in PREFLIGHT_REPO_ROOT, not in /tmp/config/.env.
+        """
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, cwd="/tmp")
+        # The script should read our mock .env successfully.
+        # If anchoring were broken it would fail with "config/.env missing".
+        assert "✓ required_env_vars" in result.stdout
+
+    def test_no_false_env_failure_from_wrong_cwd(self, tmp_path):
+        """
+        If the script used ./config/.env (relative to cwd), running from /tmp
+        would produce a required_env_vars failure even with a valid .env.
+        This test asserts that doesn't happen.
+        """
+        mock = make_full_mock_bin(tmp_path)
+        result = run(tmp_path, mock, cwd="/tmp")
+        # Should NOT fail due to missing .env
+        fail_checks_in_output = "required_env_vars" in result.stdout and "✗" in result.stdout
+        # If anchoring works, required_env_vars passes
+        assert "✓ required_env_vars" in result.stdout

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -480,10 +480,20 @@ class TestPortAvailable:
     def test_no_port_check_tools_warns(self, tmp_path):
         """When neither ss nor lsof is available, emit warn instead of silently passing."""
         mock = make_full_mock_bin(tmp_path, port_in_use=None)
-        (mock / "ss").unlink()  # Remove ss; lsof was never added
-        # Restrict PATH to mock_bin only so system ss/lsof cannot leak in
-        result = run(tmp_path, mock, extra_env={"PATH": str(mock)})
-        assert result.returncode == 0  # warn, not fail
+        # Override the 'command' builtin via BASH_ENV so that 'command -v ss'
+        # and 'command -v lsof' return 1 regardless of PATH, simulating a
+        # minimal host where neither port-checking tool is installed.
+        bash_env = tmp_path / "no_port_tools_env.sh"
+        bash_env.write_text(
+            "command() {\n"
+            "    if [ \"$1\" = \"-v\" ] && { [ \"$2\" = \"ss\" ] || [ \"$2\" = \"lsof\" ]; }; then\n"
+            "        return 1\n"
+            "    fi\n"
+            "    builtin command \"$@\"\n"
+            "}\n"
+        )
+        result = run(tmp_path, mock, extra_env={"BASH_ENV": str(bash_env)})
+        assert result.returncode == 0  # warn exits 0, not fail
         assert "⚠ port_available" in result.stdout
         assert "neither ss nor lsof" in result.stdout
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -116,6 +116,7 @@ class TestShellSyntax:
         "bin/poke.sh",
         "bin/heartbeat.sh",
         "bin/create-agent.sh",
+        "bin/preflight.sh",
     ])
     def test_shell_syntax_valid(self, script):
         """bash -n checks syntax without executing."""


### PR DESCRIPTION
## Summary

- **`bin/preflight.sh`** — pre-install host state checker with 8 checks, three-state pass/warn/fail output, `--json` and `--quiet` flags, and `BASH_SOURCE` anchoring so it works from any cwd
- **`tests/test_preflight.py`** — 48-test suite covering every check path plus flags and anchoring behaviour; marked-slow tests cover the timeout cases
- **`Makefile`** — `make install` wraps `./bin/preflight.sh && docker compose pull && docker compose up -d`
- **`docs/QUICKSTART.md`** — Start section now calls preflight before compose
- **`.github/workflows/ci.yml`** — new `preflight` job runs the test suite on every push/PR
- **`tests/test_setup.py`** — `bin/preflight.sh` added to shell-syntax parametrize list

Implements spec `2026-04-30-karakos-preflight-script.md` (iter-2), closes #71.

## Checks implemented

| # | Name | Fail / Warn condition |
|---|------|-----------------------|
| 1 | `docker_engine_reachable` | docker not found or times out (exit 124) |
| 2 | `docker_compose_v2` | compose not found or version < v2 |
| 3 | `wsl_integration_healthy` | WSL-only; permission denied / distro not running / timeout |
| 4 | `architecture_supported` | `uname -m` not x86\_64 / aarch64 / arm64 |
| 5 | `shell_script_line_endings` | any `bin/*.sh` or `bin/kara` has CRLF |
| 6 | `required_env_vars` | `config/.env` missing, or DASHBOARD\_PORT / AGENT\_SERVER\_TOKEN / any DISCORD token absent |
| 7 | `port_available` | DASHBOARD\_PORT already bound (`ss` → `lsof` fallback) |
| 8 | `disk_space` | Docker root < 5 GB (fail) or < 10 GB (warn) |

## Test plan

- [ ] CI `preflight` job passes (bash -n + pytest 48 tests)
- [ ] `make install` halts cleanly when preflight exits 1
- [ ] `./bin/preflight.sh --json` emits valid JSON with `status`, `warnings`, `failures` fields
- [ ] `./bin/preflight.sh --quiet` suppresses passing checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)