### PR TITLE
install.ps1: install host Python 3.12 for karakos-admin MCP

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -117,6 +117,40 @@ if (-not $hasJq) {
     Write-Step "jq found."
 }
 
+# --- Install Python ---
+# Required on the host (not just inside the container) because the repo's
+# root .mcp.json registers `karakos-admin` as `python3 mcp/admin-server.py`.
+# Claude Code on the host spawns that MCP server, so it needs a real python3
+# on PATH. Windows 11 ships a `python3` Microsoft Store stub on PATH that
+# opens the Store and exits non-zero when invoked — treat that as "not
+# installed" and install the real thing.
+function Test-RealPython3 {
+    $cmd = Get-Command python3 -ErrorAction SilentlyContinue
+    if (-not $cmd) { return $false }
+    # Reject the WindowsApps Store stub (path under WindowsApps that exits 9009 on invoke).
+    if ($cmd.Source -like "*\WindowsApps\*") { return $false }
+    try {
+        $ver = & python3 --version 2>&1
+        return ($LASTEXITCODE -eq 0 -and $ver -match "^Python 3\.")
+    } catch {
+        return $false
+    }
+}
+
+if (-not (Test-RealPython3)) {
+    Write-Step "Installing Python 3.12..."
+    winget install --id Python.Python.3.12 -e --accept-source-agreements --accept-package-agreements
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    if (-not (Test-RealPython3)) {
+        Write-Err "Python installed but 'python3' is not resolving on PATH."
+        Write-Err "You may need to restart your shell or sign out/in, then re-run install.ps1."
+        exit 1
+    }
+    Write-Step "Python 3.12 installed."
+} else {
+    Write-Step "Python found: $((& python3 --version) 2>&1)"
+}
+
 # --- Clone repository ---
 if (Test-Path $InstallDir) {
     Write-Step "Directory $InstallDir already exists."


### PR DESCRIPTION
## Summary
- Adds a Python 3.12 install step to `install.ps1` so the root `.mcp.json`'s `karakos-admin` server (`python3 mcp/admin-server.py`) actually works for Windows users.
- Detects and rejects the Windows 11 `python3` Microsoft Store stub (path under `\WindowsApps\`, exits non-zero) so already-installed real Pythons aren't reinstalled over.

## Why
Reported by Ian during a fresh install. Container has its own Python 3.11, but the host's Claude Code spawns the `karakos-admin` MCP server on the host, which needs a real `python3` on PATH. install.ps1 installed Git, Docker Desktop, and jq — not Python.

## Test plan
- [ ] On a clean Windows 11 box with no Python: run `install.ps1`, confirm `winget` installs Python 3.12, confirm `python3 --version` works in a new shell, confirm `karakos-admin` MCP server starts in Claude Code from the install dir.
- [ ] On a Windows box with only the MS Store `python3` stub: confirm `Test-RealPython3` returns false and the real Python is installed.
- [ ] On a Windows box with a real Python already on PATH: confirm install is skipped and version is logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)